### PR TITLE
feat: integrate drf-spectacular for swagger documentation

### DIFF
--- a/reats/requirements.txt
+++ b/reats/requirements.txt
@@ -9,6 +9,7 @@ djangorestframework-simplejwt[crypto]==5.3.1
 django-stubs[compatible-mypy]==4.2.3
 djangorestframework==3.14.0
 djangorestframework-stubs[compatible-mypy]==3.14.2
+drf-spectacular==0.29.0
 freezegun==1.2.2
 googlemaps==4.10.0
 gunicorn==20.1.0

--- a/reats/source/settings.py
+++ b/reats/source/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "django_filters",
+    "drf_spectacular",
     "customer_app",
     "cooker_app",
     "delivery_app",
@@ -198,6 +199,31 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Reats Cooker API",
+    "DESCRIPTION": "API for Reats Cooker Application",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SERVE_PERMISSIONS": ["rest_framework.permissions.AllowAny"],
+    "APPEND_COMPONENTS": {
+        "securitySchemes": {
+            "ApiKeyAuth": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-Api-Key",
+            },
+            "AppOrigin": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "App-Origin",
+            },
+        },
+    },
+    "SECURITY": [{"ApiKeyAuth": [], "BearerAuth": [], "AppOrigin": []}],
 }
 
 

--- a/reats/source/urls.py
+++ b/reats/source/urls.py
@@ -5,6 +5,7 @@ from delivery_app import views as delivery_app_views
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
@@ -95,6 +96,17 @@ urlpatterns = [
         "api/v1/stripe/webhook/",
         customer_app_views.StripeWebhookView.as_view({"post": "create"}),
         name="stripe_webhook",
+    ),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/docs/swagger/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/docs/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
     ),
 ]
 


### PR DESCRIPTION
##Issue  REA-91

# Documentation with Swagger (OpenAPI 3)

- Added drf-spectacular to requirements and installed apps
- Configured SPECTACULAR_SETTINGS with public access (AllowAny)
- Added security schemes for X-Api-Key, App-Origin, and Bearer Token
- Registered schema and documentation endpoints in urls.py