### PR TITLE
fix: resolve Swagger 406 Not Acceptable error by adding BrowsableAPIR…

### DIFF
--- a/reats/source/settings.py
+++ b/reats/source/settings.py
@@ -182,7 +182,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATIC_URL = os.path.join(BASE_DIR, "staticfiles/")
+STATIC_URL = "/static/"
 
 PHONE_REGION = "FR"
 PHONE_BLACK_LIST = ("0000000000",)  # Check if we need to add more numbers
@@ -197,7 +197,10 @@ REST_FRAMEWORK = {
         "rest_framework.parsers.FormParser",
         "rest_framework.parsers.MultiPartParser",
     ],
-    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
+    "DEFAULT_RENDERER_CLASSES": (
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
+    ),
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
#Issue REA-94:  Corriger le 406 Not Acceptable error de Swagger

## Modifications effectuées :

Ajout de BrowsableAPIRenderer dans DEFAULT_RENDERER_CLASSES (ce qui permet au serveur de répondre au format HTML demandé par le navigateur pour Swagger UI).
Correction de STATIC_URL (passé de chemin local à /static/).