### PR TITLE
feat(api): implement paginated popular-items endpoint

### DIFF
--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Dict, Union
 
 import phonenumbers
@@ -258,20 +259,25 @@ class RecentReviewSerializer(serializers.Serializer):
 
 
 class PopularItemSerializer(serializers.Serializer):
-    id = serializers.CharField()
-    name = serializers.CharField()
-    number_of_sold_items = serializers.IntegerField()
-    revenue = serializers.DecimalField(max_digits=10, decimal_places=2)
-    image = serializers.CharField(allow_blank=True, allow_null=True)
+    """Serializer for popular items that handles transformation from QuerySet union."""
+
+    item_id = serializers.UUIDField(source="id")
+    item_name = serializers.CharField(source="name")
+    total_sold = serializers.IntegerField(source="number_of_sold_items")
+    item_price = serializers.DecimalField(max_digits=10, decimal_places=2, write_only=True)
+    item_photo = serializers.CharField(allow_blank=True, allow_null=True, write_only=True)
 
     def to_representation(self, instance):
-        data = super().to_representation(instance)
+        """Transform QuerySet values dict to API response format."""
+        revenue = Decimal(str(instance.get("item_price", 0))) * instance.get("total_sold", 0)
+        photo = instance.get("item_photo")
+
         return {
-            "id": data["id"],
-            "name": data["name"],
-            "numberOfSoldItems": data["number_of_sold_items"],
-            "revenue": data["revenue"],
-            "image": data["image"],
+            "id": str(instance["item_id"]),
+            "name": instance["item_name"],
+            "numberOfSoldItems": instance["total_sold"],
+            "revenue": float(revenue),
+            "image": get_pre_signed_url(photo) if photo else None,
         }
 
 

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Callable, List, Optional, Tuple, Type, TypedDict, Union
 
-from core_app.models import CookerModel, DishModel, DrinkModel, OrderDishItemModel, OrderModel
+from core_app.models import CookerModel, DishModel, DrinkModel, OrderDishItemModel, OrderDrinkItemModel, OrderModel
 from core_app.serializers import (
     DishGETSerializer,
     DrinkGETSerializer,
@@ -14,7 +14,7 @@ from core_app.serializers import (
 )
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import Count, Q, QuerySet, Sum
+from django.db.models import Count, F, Q, QuerySet, Sum
 from django.utils import timezone
 from phonenumbers.phonenumberutil import NumberParseException
 from rest_framework import status
@@ -34,7 +34,6 @@ from utils.common import (
     create_stripe_refund,
     delete_s3_object,
     format_phone,
-    get_pre_signed_url,
     is_otp_valid,
     send_otp,
     update_cooker_acceptance_rate,
@@ -53,6 +52,7 @@ from utils.enums import (
     WeekChartLabelEnum,
     YearChartLabelEnum,
 )
+from utils.paginations import StandardizedResultsSetPagination
 
 from .serializers import (
     CookerGETSerializer,
@@ -63,6 +63,7 @@ from .serializers import (
     DishPOSTSerializer,
     DrinkPATCHSerializer,
     DrinkPOSTSerializer,
+    PopularItemSerializer,
     TokenObtainPairWithoutPasswordSerializer,
     TokenObtainRefreshWithoutPasswordSerializer,
 )
@@ -268,6 +269,7 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
 
 class DashboardView(StandardizedResponseMixin, GenericViewSet):
     permission_classes = [UserPermission]
+    pagination_class = StandardizedResultsSetPagination
 
     def list(self, request) -> Response:
         start_date_str: Union[str, None] = request.query_params.get("start_date")
@@ -320,6 +322,23 @@ class DashboardView(StandardizedResponseMixin, GenericViewSet):
 
         serializer = DashboardStatsSerializer(data=data)
         serializer.is_valid(raise_exception=True)
+        return self.success(data=serializer.data)
+
+    @action(methods=["get"], detail=False, url_path="popular-items")
+    def popular_items(self, request) -> Response:
+        """Return paginated list of popular items for the given period."""
+        period = request.query_params.get("period", TimeFrameEnum.TODAY.value)
+        cooker_id = request.user.pk
+
+        date_range = self._get_date_range(period)
+        queryset = self._get_popular_items_queryset(cooker_id, date_range)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = PopularItemSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = PopularItemSerializer(queryset, many=True)
         return self.success(data=serializer.data)
 
     def _get_date_range(self, period: str) -> DateRangeDict:
@@ -505,32 +524,43 @@ class DashboardView(StandardizedResponseMixin, GenericViewSet):
             )
         return reviews
 
-    def _get_popular_items(self, cooker_id: int, date_range: DateRangeDict, limit: int = 5) -> List[dict[str, Any]]:
-        dish_items = (
+    def _get_popular_items_queryset(self, cooker_id: int, date_range: DateRangeDict) -> QuerySet:
+        """Return combined QuerySet of popular dishes and drinks using union."""
+        # Get popular dishes with normalized field names
+        dishes = (
             OrderDishItemModel.objects.filter(
                 order__cooker_id=cooker_id,
                 order__created__gte=date_range["current_period_start"],
                 order__status=OrderStatusEnum.DELIVERED,
             )
-            .values("dish__id", "dish__name", "dish__photo", "dish__price")
+            .values(
+                item_id=F("dish__id"),
+                item_name=F("dish__name"),
+                item_photo=F("dish__photo"),
+                item_price=F("dish__price"),
+            )
             .annotate(total_sold=Sum("dish_quantity"))
-            .order_by("-total_sold")[:limit]
         )
 
-        popular: List[dict[str, Any]] = []
-        for item in dish_items:
-            photo_url = get_pre_signed_url(item["dish__photo"]) if item["dish__photo"] else None
-            popular.append(
-                {
-                    "id": str(item["dish__id"]),
-                    "name": item["dish__name"],
-                    "number_of_sold_items": item["total_sold"],
-                    "revenue": Decimal(str(item["dish__price"])) * item["total_sold"],
-                    "image": photo_url,
-                }
+        # Get popular drinks with normalized field names
+        drinks = (
+            OrderDrinkItemModel.objects.filter(
+                order__cooker_id=cooker_id,
+                order__created__gte=date_range["current_period_start"],
+                order__status=OrderStatusEnum.DELIVERED,
             )
+            .values(
+                item_id=F("drink__id"),
+                item_name=F("drink__name"),
+                item_photo=F("drink__photo"),
+                item_price=F("drink__price"),
+            )
+            .annotate(total_sold=Sum("drink_quantity"))
+        )
 
-        return popular[:limit]
+        # Combine using union and order by total_sold
+        # Note: union() requires identical field names and types
+        return dishes.union(drinks).order_by("-total_sold")
 
     def _calculate_trend(self, current: float, previous: float) -> Union[str, None]:
         if not previous:

--- a/reats/tests/cooker_app/dashboard/conftest.py
+++ b/reats/tests/cooker_app/dashboard/conftest.py
@@ -11,3 +11,9 @@ import pytest
 def dashboard_stats_path() -> str:
     """Path de l'endpoint dashboard stats."""
     return "/api/v1/cookers-dashboard/stats/"
+
+
+@pytest.fixture
+def popular_items_path() -> str:
+    """Path de l'endpoint dashboard popular-items."""
+    return "/api/v1/cookers-dashboard/popular-items/"

--- a/reats/tests/cooker_app/dashboard/popular_items/__init__.py
+++ b/reats/tests/cooker_app/dashboard/popular_items/__init__.py
@@ -1,0 +1,1 @@
+"""Popular items tests package."""

--- a/reats/tests/cooker_app/dashboard/popular_items/conftest.py
+++ b/reats/tests/cooker_app/dashboard/popular_items/conftest.py
@@ -1,0 +1,1 @@
+"""Conftest for popular items tests."""

--- a/reats/tests/cooker_app/dashboard/popular_items/conftest.py
+++ b/reats/tests/cooker_app/dashboard/popular_items/conftest.py
@@ -1,1 +1,28 @@
 """Conftest for popular items tests."""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+from utils.enums import SuccessMessageEnum
+
+
+@pytest.fixture
+def get_popular_items(client: APIClient, auth_headers: dict, popular_items_path: str):
+    """Fixture to call popular items endpoint and assert basic success."""
+
+    def _call(params: dict | None = None) -> dict:
+        response = client.get(
+            popular_items_path,
+            params or None,
+            follow=False,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        payload = response.json()
+        assert payload["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
+        assert payload["success"] is True
+        assert "data" in payload
+        return payload
+
+    return _call

--- a/reats/tests/cooker_app/dashboard/popular_items/test_api.py
+++ b/reats/tests/cooker_app/dashboard/popular_items/test_api.py
@@ -3,108 +3,41 @@
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
-from utils.enums import SuccessMessageEnum, TimeFrameEnum
+from utils.enums import TimeFrameEnum
 
 
 @pytest.mark.django_db
 class TestPopularItemsAPI:
     """Tests for the DashboardView popular_items action."""
 
-    def test_get_popular_items_success(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        popular_items_path: str,
-    ) -> None:
-        """Test GET /dashboard/popular-items successfully."""
-        response = client.get(
-            popular_items_path,
-            follow=False,
-            **auth_headers,
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json(), dict)
-        assert "success" in response.json()
-        assert "data" in response.json()
-        assert "message" in response.json()
-        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
-        assert response.json()["success"] is True
-        data = response.json()["data"]
-
+    def test_get_popular_items_success(self, get_popular_items):
+        payload = get_popular_items()
+        data = payload["data"]
         assert "results" in data
         assert "pagination" in data
         assert isinstance(data["results"], list)
 
-    def test_get_popular_items_with_period(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        popular_items_path: str,
-    ) -> None:
+    def test_get_popular_items_with_period(self, get_popular_items):
         """Test GET /dashboard/popular-items?period=month successfully."""
-        response = client.get(
-            popular_items_path,
-            {"period": TimeFrameEnum.MONTH.value},
-            follow=False,
-            **auth_headers,
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert "message" in response.json()
-        assert "success" in response.json()
-        assert "data" in response.json()
-
-        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
-        assert response.json()["success"] is True
-        data = response.json()["data"]
+        payload = get_popular_items({"period": TimeFrameEnum.MONTH.value})
+        data = payload["data"]
         assert "results" in data
 
-    def test_get_popular_items_pagination(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        popular_items_path: str,
-    ) -> None:
+    def test_get_popular_items_pagination(self, get_popular_items):
         """Test pagination for popular items."""
-        response = client.get(
-            popular_items_path,
-            {"page": 1, "page_size": 2},
-            follow=False,
-            **auth_headers,
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert "message" in response.json()
-        assert "success" in response.json()
-        assert "data" in response.json()
-
-        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
-        assert response.json()["success"] is True
-
-        data = response.json()["data"]
+        payload = get_popular_items({"page": 1, "page_size": 2})
+        data = payload["data"]
         assert "results" in data
         assert "pagination" in data
         assert len(data["results"]) <= 2
         assert data["pagination"]["items_per_page"] == 2
 
-    def test_get_popular_items_structure(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        popular_items_path: str,
-    ) -> None:
+    def test_get_popular_items_structure(self, get_popular_items):
         """Test the structure of popular items in the results."""
-        response = client.get(
-            popular_items_path,
-            follow=False,
-            **auth_headers,
-        )
+        payload = get_popular_items()
+        results = payload["data"]["results"]
 
-        assert response.status_code == status.HTTP_200_OK
-        results = response.json()["data"]["results"]
-
-        if len(results) > 0:
+        if results:
             item = results[0]
             assert "id" in item
             assert "name" in item

--- a/reats/tests/cooker_app/dashboard/popular_items/test_api.py
+++ b/reats/tests/cooker_app/dashboard/popular_items/test_api.py
@@ -1,0 +1,126 @@
+"""Tests for the Dashboard Popular Items endpoint."""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+from utils.enums import SuccessMessageEnum, TimeFrameEnum
+
+
+@pytest.mark.django_db
+class TestPopularItemsAPI:
+    """Tests for the DashboardView popular_items action."""
+
+    def test_get_popular_items_success(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        popular_items_path: str,
+    ) -> None:
+        """Test GET /dashboard/popular-items successfully."""
+        response = client.get(
+            popular_items_path,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), dict)
+        assert "success" in response.json()
+        assert "data" in response.json()
+        assert "message" in response.json()
+        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
+        assert response.json()["success"] is True
+        data = response.json()["data"]
+
+        assert "results" in data
+        assert "pagination" in data
+        assert isinstance(data["results"], list)
+
+    def test_get_popular_items_with_period(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        popular_items_path: str,
+    ) -> None:
+        """Test GET /dashboard/popular-items?period=month successfully."""
+        response = client.get(
+            popular_items_path,
+            {"period": TimeFrameEnum.MONTH.value},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "message" in response.json()
+        assert "success" in response.json()
+        assert "data" in response.json()
+
+        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
+        assert response.json()["success"] is True
+        data = response.json()["data"]
+        assert "results" in data
+
+    def test_get_popular_items_pagination(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        popular_items_path: str,
+    ) -> None:
+        """Test pagination for popular items."""
+        response = client.get(
+            popular_items_path,
+            {"page": 1, "page_size": 2},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "message" in response.json()
+        assert "success" in response.json()
+        assert "data" in response.json()
+
+        assert response.json()["message"] == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
+        assert response.json()["success"] is True
+
+        data = response.json()["data"]
+        assert "results" in data
+        assert "pagination" in data
+        assert len(data["results"]) <= 2
+        assert data["pagination"]["items_per_page"] == 2
+
+    def test_get_popular_items_structure(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        popular_items_path: str,
+    ) -> None:
+        """Test the structure of popular items in the results."""
+        response = client.get(
+            popular_items_path,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["data"]["results"]
+
+        if len(results) > 0:
+            item = results[0]
+            assert "id" in item
+            assert "name" in item
+            assert "numberOfSoldItems" in item
+            assert "revenue" in item
+            assert "image" in item
+
+    def test_get_popular_items_unauthenticated(
+        self,
+        client: APIClient,
+        popular_items_path: str,
+    ) -> None:
+        """Test that unauthenticated access returns 401."""
+        response = client.get(
+            popular_items_path,
+            follow=False,
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
# Issue REA-89:  Création du module items populaire

## Implémentation complète de l'endpoint GET /dashboard/popular-items avec pagination.

- Types supportés : Retourne à la fois les Plats (dishes) et les Boissons (drinks).

- Tri : Les items sont triés par popularité (numberOfSoldItems décroissant).

- Pagination : Utilise StandardizedResultsSetPagination `(ex: ?page=1&page_size=10).`

- Filtre : Supporte le filtre par période `(?period=today|week|month|year)`.

