### PR TITLE
Feat/rea 115 implement search filter togle availabity

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Callable, List, Optional, Tuple, Type, TypedDict, Union
 
+import django_filters
 from core_app.models import CookerModel, DishModel, DrinkModel, OrderDishItemModel, OrderDrinkItemModel, OrderModel
 from core_app.serializers import (
     DishGETSerializer,
@@ -51,6 +52,7 @@ from utils.enums import (
     WeekChartLabelEnum,
     YearChartLabelEnum,
 )
+from utils.filters import DishFilter
 from utils.paginations import StandardizedResultsSetPagination
 
 from .serializers import (
@@ -572,6 +574,15 @@ class DashboardView(StandardizedResponseMixin, GenericViewSet):
 
 class DishView(StandardizedResponseMixin, ModelViewSet):
     queryset = DishModel.objects.filter(is_deleted=False).all()
+    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
+    filterset_class = DishFilter
+
+    def get_queryset(self):
+        # For detail actions, restrict to dishes owned by the authenticated cooker.
+        # super().get_queryset() already applies is_deleted=False from the class-level queryset.
+        if self.action in ("retrieve", "update", "partial_update", "destroy", "toggle_availability"):
+            return super().get_queryset().filter(cooker__id=self.request.user.pk)
+        return super().get_queryset()
 
     def get_serializer_class(self) -> type[BaseSerializer]:
         if self.request.method in ("POST", "PUT"):
@@ -689,6 +700,14 @@ class DishView(StandardizedResponseMixin, ModelViewSet):
             return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True)
+        return self.success(data=serializer.data)
+
+    @action(detail=True, methods=["patch"], url_path="availability")
+    def toggle_availability(self, request, *args, **kwargs) -> Response:
+        instance: DishModel = self.get_object()
+        instance.is_enabled = not instance.is_enabled
+        instance.save(update_fields=["is_enabled", "modified"])
+        serializer = self.get_serializer(instance)
         return self.success(data=serializer.data)
 
     def destroy(self, request, *args, **kwargs) -> Response:

--- a/reats/tests/cooker_app/dishes/update/test_menu_management.py
+++ b/reats/tests/cooker_app/dishes/update/test_menu_management.py
@@ -1,0 +1,167 @@
+import pytest
+from core_app.models import DishModel
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+class TestDishAvailabilityToggle:
+    """Tests for PATCH /api/v1/dishes/:id/availability/"""
+
+    def test_toggle_from_enabled_to_disabled(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        # Dish pk=4 belongs to cooker 1 and is enabled by default
+        dish = DishModel.objects.get(pk=4)
+        assert dish.is_enabled is True
+
+        response = client.patch(
+            f"{path}{dish.pk}/availability/",
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json().get("success") is True
+        dish.refresh_from_db()
+        assert dish.is_enabled is False
+        assert response.json()["data"]["is_enabled"] is False
+
+    def test_toggle_from_disabled_to_enabled(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        # Dish pk=10 belongs to cooker 1 and is disabled (is_enabled=false in fixture)
+        dish = DishModel.objects.get(pk=10)
+        assert dish.is_enabled is False
+
+        response = client.patch(
+            f"{path}{dish.pk}/availability/",
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json().get("success") is True
+        dish.refresh_from_db()
+        assert dish.is_enabled is True
+        assert response.json()["data"]["is_enabled"] is True
+
+    def test_toggle_returns_404_for_other_cooker_dish(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        # Dish pk=1 belongs to cooker 4, not cooker 1 (auth_headers is for cooker 1)
+        response = client.patch(
+            f"{path}1/availability/",
+            follow=False,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestDishSearchFilter:
+    """Tests for GET /api/v1/dishes/?search=<name>"""
+
+    def test_search_returns_matching_dishes(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        response = client.get(
+            path,
+            {"search": "poulet", "is_enabled": "true"},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json().get("data")
+        assert len(data) > 0
+        for item in data:
+            assert "poulet" in item["name"].lower()
+
+    def test_search_is_case_insensitive(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        response = client.get(
+            path,
+            {"search": "POULET", "is_enabled": "true"},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json().get("data")
+        assert len(data) > 0
+
+    def test_search_returns_empty_for_no_match(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        response = client.get(
+            path,
+            {"search": "xyznotexist", "is_enabled": "true"},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json().get("data") == []
+
+
+@pytest.mark.django_db
+class TestDishAvailableFilter:
+    """Tests for GET /api/v1/dishes/?available=true|false"""
+
+    def test_available_true_returns_only_enabled(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        response = client.get(
+            path,
+            {"available": "true"},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json().get("data")
+        assert len(data) > 0
+        for item in data:
+            assert item["is_enabled"] is True
+
+    def test_available_false_returns_only_disabled(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        response = client.get(
+            path,
+            {"available": "false", "is_enabled": "false"},
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json().get("data")
+        assert len(data) > 0
+        for item in data:
+            assert item["is_enabled"] is False

--- a/reats/utils/filters.py
+++ b/reats/utils/filters.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 import django_filters
-from core_app.models import OrderModel
+from core_app.models import DishModel, OrderModel
 from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db.models import Q
@@ -199,3 +199,12 @@ class OrderFilter(filters.FilterSet):
             | Q(cooker__firstname__icontains=value)
             | Q(cooker__lastname__icontains=value)
         ).distinct()
+
+
+class DishFilter(filters.FilterSet):
+    search = django_filters.CharFilter(lookup_expr="icontains", field_name="name")
+    available = django_filters.BooleanFilter(field_name="is_enabled")
+
+    class Meta:
+        model = DishModel
+        fields = ["search", "available"]


### PR DESCRIPTION
#Issue-REA-115 - Outils de Pilotage (Recherche, Filtres, Disponibilité)

##Tâche éffectuées:

- Toggle Action : Créer l'action personnalisée toggle_availability (PATCH /dishes/:id/availability/).
- Search : Améliorer le filtre search pour chercher sur le name .
- Filters : Ajouter le support des filtres available (alias de is_enabled).
- Tests : Scénarios d'intégration sur le filtrage complexe et le changement d'état rapide.


##Critères d'acceptations :

- Le dashboard peut basculer la disponibilité d'un plat via un endpoint dédié.
- Les filtres available et featured retournent les bons résultats.