### PR TITLE
fix(cooker): separate photo/info updates and atomize tests

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -136,27 +136,37 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
             )
 
     def partial_update(self, request, *args, **kwargs) -> Response:
-        kwargs.pop("pk")  # pk is unexpected in parent's partial_update method
+        kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
+        response = super().partial_update(request, *args, **kwargs)
+        return self.success(data=response.data)
+
+    def update(self, request, *args, **kwargs) -> Response:
+        kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
+        response = super().update(request, *args, **kwargs)
+        return self.success(data=response.data)
+
+    @action(detail=True, methods=["patch"], url_path="photo")
+    def photo(self, request, pk=None) -> Response:
         cooker: CookerModel = self.get_object()
         old_photo_key: str = cooker.photo
-        photo = None
 
-        try:
-            self.request.FILES["photo"]
-        except KeyError:
-            pass
-        else:
-            photo = "cookers" + "/" + str(cooker.pk) + "/" + "profile_pics" + "/" + self.request.FILES["photo"].name
+        if "photo" not in self.request.FILES:
+            return self.error(
+                message="No photo provided",
+                code="INVALID_DATA",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
 
-        if photo is not None:
-            upload_image_to_s3(self.request.FILES["photo"], photo)
-            cooker.photo = photo
-            cooker.save()
+        photo = "cookers" + "/" + str(cooker.pk) + "/" + "profile_pics" + "/" + self.request.FILES["photo"].name
+        upload_image_to_s3(self.request.FILES["photo"], photo)
 
-            if not old_photo_key.endswith("default-profile-pic.jpg"):
-                delete_s3_object(old_photo_key)
+        cooker.photo = photo
+        cooker.save()
 
-        return super().partial_update(request, *args, **kwargs)
+        if old_photo_key and not old_photo_key.endswith("default-profile-pic.jpg"):
+            delete_s3_object(old_photo_key)
+
+        return self.success(data={"photo": cooker.photo}, message=SuccessMessageEnum.OPERATION_SUCCESSFUL)
 
     def destroy(self, request, *args, **kwargs) -> Response:
         instance: CookerModel = self.get_object()
@@ -665,6 +675,10 @@ class DishView(StandardizedResponseMixin, ModelViewSet):
             instance._prefetched_objects_cache = {}
 
         return self.success(data=serializer.data)
+
+    def partial_update(self, request, *args, **kwargs):
+        kwargs["partial"] = True
+        return self.update(request, *args, **kwargs)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/reats/tests/cooker_app/cookers/update/test_api.py
+++ b/reats/tests/cooker_app/cookers/update/test_api.py
@@ -1,6 +1,5 @@
 import os
 from datetime import datetime, timedelta
-from io import BytesIO
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -12,7 +11,6 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from freezegun import freeze_time
-from PIL import Image
 from rest_framework import status
 from rest_framework.test import APIClient
 from utils.enums import ErrorCodeEnum
@@ -54,242 +52,175 @@ def cooker_id() -> int:
 
 
 @pytest.mark.django_db
-class TestUpdateCookerAddressInfo:
-    def test_response(
+class TestUpdateCookerInfoSuccess:
+    def test_update_personal_info(
         self,
         auth_headers: dict,
         client: APIClient,
-        delete_object: MagicMock,
-        cooker_id: int,
-        path: str,
-        post_address_data: dict,
-        upload_fileobj: MagicMock,
-    ) -> None:
-        with freeze_time("2023-10-14T22:00:00+00:00"):
-            response = client.patch(
-                f"{path}{cooker_id}/",
-                encode_multipart(BOUNDARY, post_address_data),
-                content_type=MULTIPART_CONTENT,
-                follow=False,
-                **auth_headers,
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-
-            cooker = CookerModel.objects.get(pk=cooker_id)
-
-            assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
-            assert cooker.postal_code == "89000"
-            assert cooker.street_name == "rue René Cassin"
-            assert cooker.street_number == "99"
-            assert cooker.town == "EVREUX"
-            assert cooker.address_complement == "résidence de la brume"
-
-            upload_fileobj.assert_not_called()
-            delete_object.assert_not_called()
-
-
-@pytest.mark.django_db
-class TestUpdateCookerAccountInfoWithoutPhoto:
-    def test_response(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        delete_object: MagicMock,
         cooker_id: int,
         path: str,
         post_personal_information_data_without_photo: dict,
-        upload_fileobj: MagicMock,
     ) -> None:
         with freeze_time("2023-10-14T22:00:00+00:00"):
             response = client.patch(
                 f"{path}{cooker_id}/",
                 encode_multipart(BOUNDARY, post_personal_information_data_without_photo),
                 content_type=MULTIPART_CONTENT,
-                follow=False,
                 **auth_headers,
             )
 
             assert response.status_code == status.HTTP_200_OK
+            assert response.json()["success"] is True
 
             cooker = CookerModel.objects.get(pk=cooker_id)
-
-            assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
             assert cooker.firstname == "John"
             assert cooker.lastname == "DOE"
-            assert cooker.max_order_number == 12
+            assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
 
-            upload_fileobj.assert_not_called()
-            delete_object.assert_not_called()
-
-
-@pytest.mark.django_db
-class TestUpdateCookerAccountInfoWithPhotoV1:
-    """
-    Here the initial photo is the default one which is not supposed
-    to be deleted by the update
-    """
-
-    def test_response(
+    def test_update_address(
         self,
         auth_headers: dict,
         client: APIClient,
-        delete_object: MagicMock,
         cooker_id: int,
         path: str,
-        post_personal_information_data_with_photo: dict,
-        upload_fileobj: MagicMock,
+        post_address_data: dict,
     ) -> None:
-        with freeze_time("2023-10-14T22:00:00+00:00"):
-            response = client.patch(
-                f"{path}{cooker_id}/",
-                encode_multipart(BOUNDARY, post_personal_information_data_with_photo),
-                content_type=MULTIPART_CONTENT,
-                follow=False,
-                **auth_headers,
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-
-            cooker = CookerModel.objects.get(pk=cooker_id)
-
-            assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
-            assert cooker.firstname == "John"
-            assert cooker.lastname == "DOE"
-            assert cooker.max_order_number == 12
-            assert cooker.photo == "cookers/1/profile_pics/test.jpg"
-
-            upload_fileobj.assert_called_once()
-            assert len(upload_fileobj.call_args.args) == 3
-
-            arg1, arg2, arg3 = upload_fileobj.call_args.args
-
-            assert isinstance(arg1, InMemoryUploadedFile)
-            assert arg1.name == "test.jpg"
-            assert arg2 == "reats-dev-bucket"
-            assert arg3 == "cookers/1/profile_pics/test.jpg"
-            delete_object.assert_not_called()
-
-
-@pytest.mark.django_db
-class TestUpdateCookerAccountInfoWithPhotoV2:
-    """
-    Here the initial photo is not the default one so we expect a deletion in S3 here.
-    """
-
-    @pytest.fixture
-    def second_profile_pic(self) -> InMemoryUploadedFile:
-        im = Image.new(mode="RGB", size=(200, 200))  # create a new image using PIL
-        im_io = BytesIO()  # a BytesIO object for saving image
-        im.save(im_io, "JPEG")  # save the image to im_io
-        im_io.seek(0)  # seek to the beginning
-
-        image = InMemoryUploadedFile(
-            im_io,
-            None,
-            "second_profile_pic.jpg",
-            "image/jpeg",
-            len(im_io.getvalue()),
-            None,
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            encode_multipart(BOUNDARY, post_address_data),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
         )
 
-        return image
+        assert response.status_code == status.HTTP_200_OK
+        cooker = CookerModel.objects.get(pk=cooker_id)
+        assert cooker.postal_code == "89000"
+        assert cooker.street_name == "rue René Cassin"
 
-    @pytest.fixture
-    def second_post_personal_information_data_with_photo(
-        self,
-        second_profile_pic: InMemoryUploadedFile,
-    ) -> dict:
-        return {
-            "firstname": "John",
-            "lastname": "DOE",
-            "max_order_number": 12,
-            "photo": second_profile_pic,
-        }
 
-    def test_response(
+@pytest.mark.django_db
+class TestUpdateCookerInfoFailure:
+    def test_update_info_invalid_id(
         self,
         auth_headers: dict,
         client: APIClient,
-        delete_object: MagicMock,
+        path: str,
+    ) -> None:
+        # Attempt to update a cooker that does not exist or not owned (mocking not found)
+        response = client.patch(
+            f"{path}9999/",
+            encode_multipart(BOUNDARY, {"firstname": "Ghost"}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_info_uniqueness_conflict(
+        self,
+        auth_headers: dict,
+        client: APIClient,
         cooker_id: int,
         path: str,
-        post_personal_information_data_with_photo: dict,
-        second_post_personal_information_data_with_photo: dict,
+    ) -> None:
+        # Create another cooker to collide with
+        CookerModel.objects.create(
+            phone="0711111111", email="other@test.com", siret="12345678901235", lastname="Other", firstname="User"
+        )
+
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            encode_multipart(BOUNDARY, {"phone": "0711111111"}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.django_db
+class TestUpdateCookerPhotoSuccess:
+    def test_upload_initial_photo(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+        image: InMemoryUploadedFile,
         upload_fileobj: MagicMock,
-        second_profile_pic: InMemoryUploadedFile,
+        delete_object: MagicMock,
+    ) -> None:
+        response = client.patch(
+            f"{path}{cooker_id}/photo/",
+            encode_multipart(BOUNDARY, {"photo": image}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        cooker = CookerModel.objects.get(pk=cooker_id)
+        assert "profile_pics/test.jpg" in cooker.photo
+        upload_fileobj.assert_called_once()
+        delete_object.assert_not_called()  # Default photo should not be deleted
+
+    def test_replace_existing_photo(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+        image: InMemoryUploadedFile,
+        upload_fileobj: MagicMock,
+        delete_object: MagicMock,
+    ) -> None:
+        # Setup: first photo already exists (non-default)
+        cooker = CookerModel.objects.get(pk=cooker_id)
+        cooker.photo = "cookers/1/profile_pics/old.jpg"
+        cooker.save()
+
+        response = client.patch(
+            f"{path}{cooker_id}/photo/",
+            encode_multipart(BOUNDARY, {"photo": image}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        delete_object.assert_called_once()
+        assert delete_object.call_args.kwargs["Key"] == "cookers/1/profile_pics/old.jpg"
+
+
+@pytest.mark.django_db
+class TestUpdateCookerPhotoFailure:
+    def test_upload_no_photo(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        response = client.patch(
+            f"{path}{cooker_id}/photo/",
+            encode_multipart(BOUNDARY, {}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["error"]["code"] == "INVALID_DATA"
+
+    def test_upload_invalid_id(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
         image: InMemoryUploadedFile,
     ) -> None:
-        with freeze_time("2023-10-14T22:00:00+00:00"):
-            response = client.patch(
-                f"{path}{cooker_id}/",
-                encode_multipart(
-                    BOUNDARY,
-                    post_personal_information_data_with_photo,
-                ),
-                content_type=MULTIPART_CONTENT,
-                follow=False,
-                **auth_headers,
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-
-            cooker = CookerModel.objects.get(pk=cooker_id)
-
-            assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
-            assert cooker.firstname == "John"
-            assert cooker.lastname == "DOE"
-            assert cooker.max_order_number == 12
-            assert cooker.photo == "cookers/1/profile_pics/test.jpg"
-
-            upload_fileobj.call_count == 1
-            assert len(upload_fileobj.call_args.args) == 3
-
-            arg1, arg2, arg3 = upload_fileobj.call_args.args
-
-            assert isinstance(arg1, InMemoryUploadedFile)
-            assert arg1.name == "test.jpg"
-            assert arg2 == "reats-dev-bucket"
-            assert arg3 == "cookers/1/profile_pics/test.jpg"
-            delete_object.assert_not_called()
-
-        # SECOND CALL #
-        with freeze_time("2023-10-22T22:00:00+00:00"):
-            response = client.patch(
-                f"{path}{cooker_id}/",
-                encode_multipart(
-                    BOUNDARY,
-                    second_post_personal_information_data_with_photo,
-                ),
-                content_type=MULTIPART_CONTENT,
-                follow=False,
-                **auth_headers,
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-
-            cooker = CookerModel.objects.get(pk=cooker_id)
-
-            assert cooker.modified.isoformat() == "2023-10-22T22:00:00+00:00"
-            assert cooker.firstname == "John"
-            assert cooker.lastname == "DOE"
-            assert cooker.max_order_number == 12
-            assert cooker.photo == "cookers/1/profile_pics/second_profile_pic.jpg"
-
-            upload_fileobj.call_count == 2
-            assert len(upload_fileobj.call_args.args) == 3
-
-            arg1, arg2, arg3 = upload_fileobj.call_args.args
-
-            assert isinstance(arg1, InMemoryUploadedFile)
-            assert arg1.name == "second_profile_pic.jpg"
-            assert arg2 == "reats-dev-bucket"
-            assert arg3 == "cookers/1/profile_pics/second_profile_pic.jpg"
-
-            delete_object.assert_called_once_with(
-                Bucket="reats-dev-bucket",
-                Key="cookers/1/profile_pics/test.jpg",
-            )
+        response = client.patch(
+            f"{path}9999/photo/",
+            encode_multipart(BOUNDARY, {"photo": image}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Issue-REA-129 [Cooker_app] - fix : Séparer la modification de la photo et des infos Cooker [https://linear.app/reats-team/issue/REA-129/cooker-app-fix-separer-la-modification-de-la-photo-et-des-infos-cooker](lien)


Séparation de l'endpoint de mise à jour du profil cooker en deux endpoints distincts :
- `PATCH /cookers/{id}/` → mise à jour des informations textuelles (nom, prénom, téléphone, adresse, etc.)
- `PATCH /cookers/{id}/photo/` → upload/remplacement de la photo de profil (S3)

## Changements
### `cooker_app/views.py`
- le partial update allégé : ne gère plus la photo ni S3
- Ajout d'un `@action(detail=True, url_path='photo')` dédié à l'upload photo
- Suppression de l'ancienne photo S3 uniquement si ce n'est pas la photo par défaut

### `tests/cooker_app/cookers/update/test_api.py`
- Remplacement des tests monolithiques par des classes atomiques :
  - \`TestUpdateCookerInfoSuccess\` — infos texte et adresse
  - \`TestUpdateCookerInfoFailure\` — ID invalide, conflit d'unicité
  - \`TestUpdateCookerPhotoSuccess\` — upload initial, remplacement photo existante
  - \`TestUpdateCookerPhotoFailure\` — pas de photo, ID invalide