### PR TITLE
Feat/rea 143 get dishes ingredients

### DIFF
--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -227,15 +227,11 @@ class DrinkSerializer(ModelSerializer):
     def update(self, instance: DrinkModel, validated_data: dict) -> DrinkModel:
         nutritional_data = validated_data.pop("nutritional_info", None)
         ingredients_data = validated_data.pop("ingredients", None)
-        ingredients_data = validated_data.pop("ingredients", None)
 
         with transaction.atomic():
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
             instance.save()
-
-            if ingredients_data is not None:
-                self._save_ingredients(instance, ingredients_data)
 
             if ingredients_data is not None:
                 self._save_ingredients(instance, ingredients_data)
@@ -320,7 +316,6 @@ class DrinkPATCHSerializer(DrinkSerializer):
             "capacity",
             "is_suitable_for_quick_delivery",
             "is_suitable_for_scheduled_delivery",
-            "ingredients",
             "ingredients",
             "nutritional_info",
         )

--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -207,7 +207,6 @@ class DrinkSerializer(ModelSerializer):
     cooker = serializers.PrimaryKeyRelatedField(queryset=CookerModel.objects.all())
     nutritional_info = serializers.JSONField(required=False, write_only=True, allow_null=True)
     ingredients = serializers.JSONField(required=False, write_only=True)
-    ingredients = serializers.JSONField(required=False, write_only=True)
 
     def create(self, validated_data: dict) -> DrinkModel:
         nutritional_data = validated_data.pop("nutritional_info", None)

--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -13,11 +13,13 @@ from core_app.models import (
     DrinkNutritionalInfo,
     IngredientDishModel,
     IngredientDrinkModel,
+    IngredientDrinkModel,
     OrderModel,
 )
 from core_app.serializers import (
     DishNutritionalInfoSerializer,
     DrinkNutritionalInfoSerializer,
+    IngredientDrinkSerializer,
     IngredientDrinkSerializer,
     OrderDishItemGETSerializer,
     OrderDrinkItemGETSerializer,
@@ -207,6 +209,7 @@ class DrinkSerializer(ModelSerializer):
     cooker = serializers.PrimaryKeyRelatedField(queryset=CookerModel.objects.all())
     nutritional_info = serializers.JSONField(required=False, write_only=True, allow_null=True)
     ingredients = serializers.JSONField(required=False, write_only=True)
+    ingredients = serializers.JSONField(required=False, write_only=True)
 
     def create(self, validated_data: dict) -> DrinkModel:
         nutritional_data = validated_data.pop("nutritional_info", None)
@@ -226,11 +229,15 @@ class DrinkSerializer(ModelSerializer):
     def update(self, instance: DrinkModel, validated_data: dict) -> DrinkModel:
         nutritional_data = validated_data.pop("nutritional_info", None)
         ingredients_data = validated_data.pop("ingredients", None)
+        ingredients_data = validated_data.pop("ingredients", None)
 
         with transaction.atomic():
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
             instance.save()
+
+            if ingredients_data is not None:
+                self._save_ingredients(instance, ingredients_data)
 
             if ingredients_data is not None:
                 self._save_ingredients(instance, ingredients_data)
@@ -315,6 +322,7 @@ class DrinkPATCHSerializer(DrinkSerializer):
             "capacity",
             "is_suitable_for_quick_delivery",
             "is_suitable_for_scheduled_delivery",
+            "ingredients",
             "ingredients",
             "nutritional_info",
         )

--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -13,13 +13,11 @@ from core_app.models import (
     DrinkNutritionalInfo,
     IngredientDishModel,
     IngredientDrinkModel,
-    IngredientDrinkModel,
     OrderModel,
 )
 from core_app.serializers import (
     DishNutritionalInfoSerializer,
     DrinkNutritionalInfoSerializer,
-    IngredientDrinkSerializer,
     IngredientDrinkSerializer,
     OrderDishItemGETSerializer,
     OrderDrinkItemGETSerializer,

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -874,17 +874,7 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
         instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
-        serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
-
-        if getattr(instance, "_prefetched_objects_cache", None):
-            instance._prefetched_objects_cache = {}
-
-        return self.success(data=serializer.data)
-
-    def partial_update(self, request, *args, **kwargs):
-        kwargs["partial"] = True
-        return self.update(request, *args, **kwargs)
 
         if getattr(instance, "_prefetched_objects_cache", None):
             instance._prefetched_objects_cache = {}
@@ -898,7 +888,6 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
     def perform_update(self, serializer: BaseSerializer) -> None:
         current_object = self.get_object()
         cooker_pk = str(current_object.cooker.pk)
-        photos = self.request.FILES.getlist("photos")
         photos = self.request.FILES.getlist("photos")
 
         if photos:

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -939,6 +939,45 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
             message=SuccessMessageEnum.DRINK_DELETED,
         )
 
+    @action(detail=False, methods=["get"], url_path="ingredients")
+    def ingredients(self, request, *args, **kwargs) -> Response:
+        queryset = IngredientDrinkModel.objects.all().order_by("name")
+        search = request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(Q(name__icontains=search) | Q(code__icontains=search))
+
+        # Categories aggregation
+        category_counts = (
+            IngredientDrinkModel.objects.filter(id__in=queryset.values_list("id", flat=True))
+            .values("category")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )
+        categories_data = [
+            {
+                "id": str(c["category"]),
+                "name": str(c["category"]).capitalize() if c["category"] else "Autre",
+                "count": c["count"],
+            }
+            for c in category_counts
+            if c["category"]
+        ]
+
+        serializer = IngredientDrinkSerializer(queryset, many=True)
+
+        # We transform the data to match the snippet (mapping id to code if needed)
+        # However, for consistency with existing REA-140, I'll keep the serializer as is
+        # but wrap it in the requested structure.
+
+        response_data = {
+            "ingredients": serializer.data,
+            "categories": categories_data,
+        }
+
+        # The snippet doesn't show pagination, but for potentially large lists,
+        # we might want to keep it. However, the requirement is strict on the structure.
+        return self.success(data=response_data)
+
 
 class TokenObtainPairWithoutPasswordView(StandardizedResponseMixin, TokenViewBase):
     serializer_class = TokenObtainPairWithoutPasswordSerializer

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -965,10 +965,6 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
 
         serializer = IngredientDrinkSerializer(queryset, many=True)
 
-        # We transform the data to match the snippet (mapping id to code if needed)
-        # However, for consistency with existing REA-140, I'll keep the serializer as is
-        # but wrap it in the requested structure.
-
         response_data = {
             "ingredients": serializer.data,
             "categories": categories_data,

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -12,6 +12,7 @@ from core_app.models import (
     DishModel,
     DrinkImageModel,
     DrinkModel,
+    IngredientDishModel,
     IngredientDrinkModel,
     OrderDishItemModel,
     OrderDrinkItemModel,
@@ -22,6 +23,7 @@ from core_app.serializers import (
     DishListSerializer,
     DrinkDetailSerializer,
     DrinkListSerializer,
+    IngredientDishSerializer,
     IngredientDrinkSerializer,
     OrderPATCHSerializer,
 )
@@ -602,11 +604,57 @@ class DashboardView(StandardizedResponseMixin, GenericViewSet):
         return f"{sign}{change:.0f}%"
 
 
-class DishView(StandardizedResponseMixin, ModelViewSet):
+class IngredientsEndpointMixin:
+    """
+    Mixin to provide the GET /{items}/ingredients/ endpoint with custom structure.
+    Requires the viewset to define `ingredient_model` and `ingredient_serializer_class`
+    and inherit from `StandardizedResponseMixin`.
+    """
+
+    ingredient_model: Any = None
+    ingredient_serializer_class: Any = None
+
+    @action(detail=False, methods=["get"], url_path="ingredients")
+    def ingredients(self, request, *args, **kwargs) -> Response:
+        queryset = self.ingredient_model.objects.all().order_by("name")
+        search = request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(Q(name__icontains=search) | Q(code__icontains=search))
+
+        category_counts = (
+            self.ingredient_model.objects.filter(id__in=queryset.values_list("id", flat=True))
+            .values("category")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )
+        categories_data = [
+            {
+                "id": str(item["category"]),
+                "name": str(item["category"]).capitalize() if item["category"] else "Autre",
+                "count": item["count"],
+            }
+            for item in category_counts
+            if item["category"]
+        ]
+
+        serializer = self.ingredient_serializer_class(queryset, many=True)
+
+        response_data = {
+            "ingredients": serializer.data,
+            "categories": categories_data,
+        }
+
+        return self.success(data=response_data)  # type: ignore
+
+
+class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet):
     queryset = DishModel.objects.filter(is_deleted=False).all()
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = DishFilter
     pagination_class = StandardizedResultsSetPagination
+
+    ingredient_model = IngredientDishModel
+    ingredient_serializer_class = IngredientDishSerializer
 
     def _annotated_queryset(self):
         return self.queryset.prefetch_related("ingredients", "images").annotate(
@@ -756,49 +804,6 @@ class DishView(StandardizedResponseMixin, ModelViewSet):
         instance.save()
 
         return self.success(message=SuccessMessageEnum.DISH_DELETED)
-
-
-class IngredientsEndpointMixin:
-    """
-    Mixin to provide the GET /{items}/ingredients/ endpoint with custom structure.
-    Requires the viewset to define `ingredient_model` and `ingredient_serializer_class`
-    and inherit from `StandardizedResponseMixin`.
-    """
-
-    ingredient_model: Any = None
-    ingredient_serializer_class: Any = None
-
-    @action(detail=False, methods=["get"], url_path="ingredients")
-    def ingredients(self, request, *args, **kwargs) -> Response:
-        queryset = self.ingredient_model.objects.all().order_by("name")
-        search = request.query_params.get("search")
-        if search:
-            queryset = queryset.filter(Q(name__icontains=search) | Q(code__icontains=search))
-
-        category_counts = (
-            self.ingredient_model.objects.filter(id__in=queryset.values_list("id", flat=True))
-            .values("category")
-            .annotate(count=Count("id"))
-            .order_by("-count")
-        )
-        categories_data = [
-            {
-                "id": str(item["category"]),
-                "name": str(item["category"]).capitalize() if item["category"] else "Autre",
-                "count": item["count"],
-            }
-            for item in category_counts
-            if item["category"]
-        ]
-
-        serializer = self.ingredient_serializer_class(queryset, many=True)
-
-        response_data = {
-            "ingredients": serializer.data,
-            "categories": categories_data,
-        }
-
-        return self.success(data=response_data)  # type: ignore
 
 
 class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet):

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -874,7 +874,17 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
         instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
+        serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+
+        if getattr(instance, "_prefetched_objects_cache", None):
+            instance._prefetched_objects_cache = {}
+
+        return self.success(data=serializer.data)
+
+    def partial_update(self, request, *args, **kwargs):
+        kwargs["partial"] = True
+        return self.update(request, *args, **kwargs)
 
         if getattr(instance, "_prefetched_objects_cache", None):
             instance._prefetched_objects_cache = {}

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -939,41 +939,6 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
             message=SuccessMessageEnum.DRINK_DELETED,
         )
 
-    @action(detail=False, methods=["get"], url_path="ingredients")
-    def ingredients(self, request, *args, **kwargs) -> Response:
-        queryset = IngredientDrinkModel.objects.all().order_by("name")
-        search = request.query_params.get("search")
-        if search:
-            queryset = queryset.filter(Q(name__icontains=search) | Q(code__icontains=search))
-
-        # Categories aggregation
-        category_counts = (
-            IngredientDrinkModel.objects.filter(id__in=queryset.values_list("id", flat=True))
-            .values("category")
-            .annotate(count=Count("id"))
-            .order_by("-count")
-        )
-        categories_data = [
-            {
-                "id": str(c["category"]),
-                "name": str(c["category"]).capitalize() if c["category"] else "Autre",
-                "count": c["count"],
-            }
-            for c in category_counts
-            if c["category"]
-        ]
-
-        serializer = IngredientDrinkSerializer(queryset, many=True)
-
-        response_data = {
-            "ingredients": serializer.data,
-            "categories": categories_data,
-        }
-
-        # The snippet doesn't show pagination, but for potentially large lists,
-        # we might want to keep it. However, the requirement is strict on the structure.
-        return self.success(data=response_data)
-
 
 class TokenObtainPairWithoutPasswordView(StandardizedResponseMixin, TokenViewBase):
     serializer_class = TokenObtainPairWithoutPasswordSerializer

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -899,6 +899,7 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
         current_object = self.get_object()
         cooker_pk = str(current_object.cooker.pk)
         photos = self.request.FILES.getlist("photos")
+        photos = self.request.FILES.getlist("photos")
 
         if photos:
             # Replace all existing images with the newly uploaded ones

--- a/reats/core_app/management/commands/init_data.py
+++ b/reats/core_app/management/commands/init_data.py
@@ -155,7 +155,7 @@ class Command(BaseCommand):
                     dish=dish,
                     defaults={
                         "calories": random.randint(100, 500),
-                        "fat": random.randint(5, 30),
+                        "fats": random.randint(5, 30),
                         "proteins": random.randint(5, 40),
                         "carbohydrates": random.randint(10, 80),
                     },
@@ -200,7 +200,7 @@ class Command(BaseCommand):
                     drink=drink,
                     defaults={
                         "calories": random.randint(20, 150),
-                        "fat": random.randint(0, 5),
+                        "fats": random.randint(0, 5),
                         "proteins": random.randint(0, 5),
                         "carbohydrates": random.randint(5, 30),
                         "sugars": random.randint(5, 25),

--- a/reats/core_app/models.py
+++ b/reats/core_app/models.py
@@ -286,21 +286,6 @@ class DrinkImageModel(ReatsModel):
         return f"Image {self.position} for {self.drink.name}"
 
 
-class DrinkImageModel(ReatsModel):
-    id: AutoField = AutoField(primary_key=True)
-    drink: ForeignKey = ForeignKey(DrinkModel, on_delete=CASCADE, related_name="images")
-    key: CharField = CharField(max_length=512)
-    is_primary: BooleanField = BooleanField(default=False)
-    position: PositiveIntegerField = PositiveIntegerField(default=0)
-
-    class Meta:
-        db_table = "drink_images"
-        ordering = ["position"]
-
-    def __str__(self) -> str:
-        return f"Image {self.position} for {self.drink.name}"
-
-
 class CustomerModel(ReatsModel):
     id: AutoField = AutoField(primary_key=True)
     firstname: CharField = CharField(max_length=100)

--- a/reats/core_app/models.py
+++ b/reats/core_app/models.py
@@ -286,6 +286,21 @@ class DrinkImageModel(ReatsModel):
         return f"Image {self.position} for {self.drink.name}"
 
 
+class DrinkImageModel(ReatsModel):
+    id: AutoField = AutoField(primary_key=True)
+    drink: ForeignKey = ForeignKey(DrinkModel, on_delete=CASCADE, related_name="images")
+    key: CharField = CharField(max_length=512)
+    is_primary: BooleanField = BooleanField(default=False)
+    position: PositiveIntegerField = PositiveIntegerField(default=0)
+
+    class Meta:
+        db_table = "drink_images"
+        ordering = ["position"]
+
+    def __str__(self) -> str:
+        return f"Image {self.position} for {self.drink.name}"
+
+
 class CustomerModel(ReatsModel):
     id: AutoField = AutoField(primary_key=True)
     firstname: CharField = CharField(max_length=100)

--- a/reats/core_app/serializers.py
+++ b/reats/core_app/serializers.py
@@ -66,7 +66,7 @@ class SimpleCookerSerializer(ModelSerializer):
         fields = ("id", "firstname", "lastname", "email", "acceptance_rate")
 
 
-class IngredientSerializer(ModelSerializer):
+class IngredientDishSerializer(ModelSerializer):
     class Meta:
         model = IngredientDishModel
         fields = ("id", "code", "name", "category", "is_allergen")
@@ -177,7 +177,7 @@ class DishListSerializer(AllergenIngredientMixin, BaseDishSerializer):
 
 
 class DishDetailSerializer(BaseDishSerializer):
-    ingredients = IngredientSerializer(many=True, read_only=True)
+    ingredients = IngredientDishSerializer(many=True, read_only=True)
     images = DishImageSerializer(many=True, read_only=True)
     allergens = serializers.SerializerMethodField()
 
@@ -190,7 +190,7 @@ class DishDetailSerializer(BaseDishSerializer):
 
     def get_allergens(self, obj: DishModel) -> Any:
         allergens = obj.ingredients.filter(is_allergen=True)
-        return IngredientSerializer(allergens, many=True).data
+        return IngredientDishSerializer(allergens, many=True).data
 
 
 class DishCustomerSerializer(AllergenIngredientMixin, NutritionalInfoMixin, ModelSerializer):

--- a/reats/tests/cooker_app/dishes/ingredients/read/test_api.py
+++ b/reats/tests/cooker_app/dishes/ingredients/read/test_api.py
@@ -1,0 +1,102 @@
+import pytest
+from core_app.models import IngredientDishModel
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def ingredients_path(path: str) -> str:
+    return f"{path}ingredients/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "ingredients_to_create",
+    [
+        [
+            {"code": "tomate", "name": "Tomate", "category": "legume", "is_allergen": False},
+            {"code": "oeuf", "name": "Oeuf", "category": "oeuf", "is_allergen": True},
+        ]
+    ],
+)
+def test_list_dish_ingredients_returns_all(
+    auth_headers: dict, client: APIClient, ingredients_path: str, ingredients_to_create: list[dict]
+) -> None:
+    for data in ingredients_to_create:
+        IngredientDishModel.objects.create(**data)
+
+    response = client.get(
+        ingredients_path,
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    assert data is not None
+    assert "ingredients" in data
+    assert "categories" in data
+
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+    assert len(ingredients) >= len(ingredients_to_create)
+
+    item = ingredients[0]
+    for key in ["id", "code", "name", "category", "is_allergen"]:
+        assert key in item
+
+    categories = data.get("categories")
+    assert isinstance(categories, list)
+    assert len(categories) > 0
+    assert "id" in categories[0]
+    assert "name" in categories[0]
+    assert "count" in categories[0]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "search_term, expected_code",
+    [
+        ("tomate", "tomate"),
+        ("oeuf", "oeuf"),
+    ],
+)
+def test_search_dish_ingredients(
+    auth_headers: dict, client: APIClient, ingredients_path: str, search_term: str, expected_code: str
+) -> None:
+    IngredientDishModel.objects.get_or_create(
+        code="tomate", defaults={"name": "Tomate", "category": "legume", "is_allergen": False}
+    )
+    IngredientDishModel.objects.get_or_create(
+        code="oeuf", defaults={"name": "Oeuf", "category": "oeuf", "is_allergen": True}
+    )
+
+    response = client.get(
+        f"{ingredients_path}?search={search_term}",
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+
+    assert any(res["code"] == expected_code for res in ingredients)
+
+
+@pytest.mark.django_db
+def test_list_dish_ingredients_empty_db(auth_headers: dict, client: APIClient, ingredients_path: str) -> None:
+    IngredientDishModel.objects.all().delete()
+
+    response = client.get(
+        ingredients_path,
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+    assert len(ingredients) == 0

--- a/reats/tests/cooker_app/dishes/ingredients/read/test_ingredients_api.py
+++ b/reats/tests/cooker_app/dishes/ingredients/read/test_ingredients_api.py
@@ -1,0 +1,102 @@
+import pytest
+from core_app.models import IngredientDishModel
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def ingredients_path(path: str) -> str:
+    return f"{path}ingredients/"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "ingredients_to_create",
+    [
+        [
+            {"code": "tomate", "name": "Tomate", "category": "legume", "is_allergen": False},
+            {"code": "oeuf", "name": "Oeuf", "category": "oeuf", "is_allergen": True},
+        ]
+    ],
+)
+def test_list_dish_ingredients_returns_all(
+    auth_headers: dict, client: APIClient, ingredients_path: str, ingredients_to_create: list[dict]
+) -> None:
+    for data in ingredients_to_create:
+        IngredientDishModel.objects.create(**data)
+
+    response = client.get(
+        ingredients_path,
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    assert data is not None
+    assert "ingredients" in data
+    assert "categories" in data
+
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+    assert len(ingredients) >= len(ingredients_to_create)
+
+    item = ingredients[0]
+    for key in ["id", "code", "name", "category", "is_allergen"]:
+        assert key in item
+
+    categories = data.get("categories")
+    assert isinstance(categories, list)
+    assert len(categories) > 0
+    assert "id" in categories[0]
+    assert "name" in categories[0]
+    assert "count" in categories[0]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "search_term, expected_code",
+    [
+        ("tomate", "tomate"),
+        ("oeuf", "oeuf"),
+    ],
+)
+def test_search_dish_ingredients(
+    auth_headers: dict, client: APIClient, ingredients_path: str, search_term: str, expected_code: str
+) -> None:
+    IngredientDishModel.objects.get_or_create(
+        code="tomate", defaults={"name": "Tomate", "category": "legume", "is_allergen": False}
+    )
+    IngredientDishModel.objects.get_or_create(
+        code="oeuf", defaults={"name": "Oeuf", "category": "oeuf", "is_allergen": True}
+    )
+
+    response = client.get(
+        f"{ingredients_path}?search={search_term}",
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+
+    assert any(res["code"] == expected_code for res in ingredients)
+
+
+@pytest.mark.django_db
+def test_list_dish_ingredients_empty_db(auth_headers: dict, client: APIClient, ingredients_path: str) -> None:
+    IngredientDishModel.objects.all().delete()
+
+    response = client.get(
+        ingredients_path,
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json().get("data")
+    ingredients = data.get("ingredients")
+    assert isinstance(ingredients, list)
+    assert len(ingredients) == 0


### PR DESCRIPTION
## Issue REA 136 (https://linear.app/reats-team/issue/REA-136/feat-mise-en-place-du-endpoint-get-dishesingredients)
## Description

Cette PR implémente l'endpoint GET /dishes/ingredients/ pour permettre le listage et la recherche d'ingrédients associés aux plats, en suivant le même modèle que celui mis en place pour les boissons.

## Changements principaux

- **Backend** :
    - Mise à jour de DishView pour utiliser IngredientsEndpointMixin.
    - Harmonisation du nommage des serializers : IngredientSerializer a été renommé en IngredientDishSerializer pour plus de clarté par rapport à IngredientDrinkSerializer.
    - Réorganisation de cooker_app/views.py pour définir le mixin avant son utilisation et corriger une NameError.
    - Ajout des imports nécessaires (IngredientDishModel, IngredientDishSerializer).

- **Tests** :
    - Création d'une suite de tests complète dans reats/tests/cooker_app/dishes/ingredients/read/test_api.py couvrant :
        - Le listage global.
        - Le groupement par catégorie avec comptage.
        - La fonctionnalité de recherche par nom/code.
        - La gestion d'une base de données vide.

