### PR TITLE
feat: add activate/deactivate drink and add trigam parameters on sett…

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -829,6 +829,9 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
         return qs
 
     def get_serializer_class(self) -> type[BaseSerializer]:
+        if self.action == "toggle_availability":
+            return DrinkListSerializer
+
         if self.request.method in ("POST", "PUT"):
             self.serializer_class = DrinkPOSTSerializer
 
@@ -934,6 +937,15 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
                 is_primary=(idx == 0),
                 position=idx,
             )
+
+    @action(detail=True, methods=["patch"], url_path="availability")
+    def toggle_availability(self, request, *args, **kwargs) -> Response:
+        instance: DrinkModel = self.get_object()
+        instance.is_enabled = not instance.is_enabled
+        instance.save(update_fields=["is_enabled", "modified"])
+        instance = self.queryset.get(pk=instance.pk)
+        serializer = self.get_serializer(instance)
+        return self.success(data=serializer.data)
 
     def destroy(self, request, *args, **kwargs) -> Response:
         instance: DrinkModel = self.get_object()

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -793,7 +793,7 @@ class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet
     def toggle_availability(self, request, *args, **kwargs) -> Response:
         instance: DishModel = self.get_object()
         instance.is_enabled = not instance.is_enabled
-        instance.save(update_fields=["is_enabled", "modified"])
+        instance.save(update_fields=["is_enabled"])
         instance = self.queryset.get(pk=instance.pk)
         serializer = self.get_serializer(instance)
         return self.success(data=serializer.data)
@@ -942,7 +942,11 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
     def toggle_availability(self, request, *args, **kwargs) -> Response:
         instance: DrinkModel = self.get_object()
         instance.is_enabled = not instance.is_enabled
-        instance.save(update_fields=["is_enabled", "modified"])
+        instance.save(
+            update_fields=[
+                "is_enabled",
+            ]
+        )
         instance = self.queryset.get(pk=instance.pk)
         serializer = self.get_serializer(instance)
         return self.success(data=serializer.data)

--- a/reats/source/settings.py
+++ b/reats/source/settings.py
@@ -249,6 +249,15 @@ DISH_SEARCH_FIELD_WEIGHTS: list[tuple[str, float]] = [
 
 DISH_SEARCH_SIMILARITY_THRESHOLD = 0.1
 
+
+DRINK_SEARCH_FIELD_WEIGHTS: list[tuple[str, float]] = [
+    ("name", 4.0),
+    ("description", 1.0),
+]
+
+DRINK_SEARCH_SIMILARITY_THRESHOLD = 0.1
+
+
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),


### PR DESCRIPTION
Cette PR introduit un nouvel endpoint qui permet aux cuisiniers (ou aux administrateurs) d’activer ou de désactiver la disponibilité d’une boisson directement via l’API. Cette fonctionnalité reflète la bascule de disponibilité existante pour les plats et garantit que les boissons indisponibles sont exclues des listes et des flux de commande.

Elle ajoute  `DRINK_SEARCH_FIELD_WEIGHTS: list[tuple[str, float]] = [
    ("name", 4.0),
    ("description", 1.0),
]

DRINK_SEARCH_SIMILARITY_THRESHOLD = 0.1
`

enfin que les la recherche fontionne bien sur la boisons 