### PR TITLE
refactor: move queryset filtering to get_queryset and add 404 test fo…

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -1063,8 +1063,11 @@ class CookerOrderView(
 
         return super().get_serializer_class()
 
+    def get_queryset(self):
+        return super().get_queryset().filter(cooker__id=self.request.user.pk)
+
     def list(self, request, *args, **kwargs) -> Response:
-        self.queryset = self.queryset.filter(cooker__id=request.user.pk)
+        queryset = self.filter_queryset(self.get_queryset())
         request_status: Union[str, None] = self.request.query_params.get("status")
 
         if request_status is None or request_status not in [
@@ -1074,12 +1077,11 @@ class CookerOrderView(
         ]:
             if request_status is not None:
                 logger.error(f"Invalid status {request_status}")
-            self.queryset = OrderModel.objects.none()
+            queryset = queryset.none()
 
         if request_status is not None:
-            self.queryset = self.queryset.filter(status=request_status).order_by("-modified")
+            queryset = queryset.filter(status=request_status).order_by("-modified")
 
-        queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/reats/tests/cooker_app/orders/update/test_api.py
+++ b/reats/tests/cooker_app/orders/update/test_api.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
-from core_app.models import CookerModel, OrderModel
+from core_app.models import AddressModel, CookerModel, CustomerModel, OrderModel
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from freezegun import freeze_time
 from rest_framework import status
@@ -566,3 +566,56 @@ def test_update_cooker_acceptance_rate(
             amount=2319,
             payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
         )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "order_status",
+    [
+        OrderStatusEnum.PENDING,
+        OrderStatusEnum.PROCESSING,
+        OrderStatusEnum.COMPLETED,
+        OrderStatusEnum.IN_DELIVERY,
+        OrderStatusEnum.CANCELLED_BY_CUSTOMER,
+        OrderStatusEnum.CANCELLED_BY_COOKER,
+        OrderStatusEnum.DELIVERED,
+    ],
+    ids=[
+        s.value
+        for s in [
+            OrderStatusEnum.PENDING,
+            OrderStatusEnum.PROCESSING,
+            OrderStatusEnum.COMPLETED,
+            OrderStatusEnum.IN_DELIVERY,
+            OrderStatusEnum.CANCELLED_BY_CUSTOMER,
+            OrderStatusEnum.CANCELLED_BY_COOKER,
+            OrderStatusEnum.DELIVERED,
+        ]
+    ],
+)
+def test_update_order_of_another_cooker_returns_404(
+    auth_headers: dict,
+    client: APIClient,
+    cookers_order_path: str,
+    order_status: OrderStatusEnum,
+) -> None:
+    other_cooker = CookerModel.objects.exclude(id=1).first()
+    assert other_cooker is not None, "Need at least another cooker in the DB"
+
+    order = OrderModel.objects.create(
+        cooker=other_cooker,
+        customer=CustomerModel.objects.first(),
+        address=AddressModel.objects.first(),
+        status=order_status.value,
+        delivery_distance=1.0,
+        delivery_fees=2.0,
+    )
+
+    update_response = client.patch(
+        f"{cookers_order_path}{order.id}/",
+        data={"status": OrderStatusEnum.PROCESSING.value},
+        format="json",
+        **auth_headers,
+    )
+
+    assert update_response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION


##  Titre
`[fix]` Correction de la faille de sécurité IDOR sur les commandes cooker

##  Contexte
- **Quel problème est résolu ?** : Un cuisinier (cooker) pouvait potentiellement accéder, lister ou modifier (via PATCH) les commandes d'un autre cuisinier en manipulant l'ID de la commande dans l'URL(Bien que se soi difficile sur mobile mais il faut etre prudent) .
- **Pourquoi ce changement est nécessaire maintenant ?** : C'est une correction de sécurité critique (IDOR - Insecure Direct Object Reference) pour garantir que chaque restaurant ne voit et n'agit que sur ses propres commandes.
- **🔗 Ticket lié** : [REA-145](https://linear.app/reats-team/issue/REA-145/fixcooker-app-correction-faille-de-securite-sur-les-commandes-cooker)

