### PR TITLE
feat: implement restricted CookerPATCHSerializer and secure viewset t…

### DIFF
--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -55,6 +55,21 @@ class CookerSerializer(ModelSerializer):
             return e164_phone_format
 
 
+class CookerPATCHSerializer(ModelSerializer):
+    class Meta:
+        model = CookerModel
+        exclude = (
+            "phone",
+            "photo",
+            "is_activated",
+            "acceptance_rate",
+            "last_acceptance_rate_update_date",
+            "is_deleted",
+            "created",
+            "modified",
+        )
+
+
 class CookerGETSerializer(ModelSerializer):
     class Meta:
         model = CookerModel

--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -69,6 +69,18 @@ class CookerPATCHSerializer(ModelSerializer):
             "modified",
         )
 
+    def to_internal_value(self, data):
+        allowed_fields = set(self.fields.keys())
+        incoming_keys = set(data.keys())
+        forbidden_keys = incoming_keys - allowed_fields
+
+        if forbidden_keys:
+            raise ValidationError(
+                {field: ["Ce champ n'est pas autorisé dans cette requête."] for field in forbidden_keys}
+            )
+
+        return super().to_internal_value(data)
+
 
 class CookerGETSerializer(ModelSerializer):
     class Meta:

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -61,7 +61,7 @@ from utils.common import (
     upload_image_to_s3,
 )
 from utils.custom_api_reponse import StandardizedResponseMixin
-from utils.custom_permissions import CustomAPIKeyPermission, UserPermission
+from utils.custom_permissions import CustomAPIKeyPermission, IsCookerOwner, UserPermission
 from utils.enums import (
     ErrorCodeEnum,
     ErrorMessageEnum,
@@ -108,6 +108,10 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
     queryset = CookerModel.objects.all()
 
     def get_queryset(self):
+        # For PATCH/PUT: expose all cookers so that a missing ID gives 404 and
+        # a valid ID belonging to another cooker gives 403 (via IsCookerOwner).
+        if self.action in ("partial_update", "update", "photo"):
+            return CookerModel.objects.all()
         if self.request.user and self.request.user.is_authenticated:
             return CookerModel.objects.filter(pk=self.request.user.pk)
         return super().get_queryset()
@@ -121,6 +125,9 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
             "otp_verify",
         ):
             permission_classes.append(CustomAPIKeyPermission)
+        elif self.action in ("partial_update", "update", "photo"):
+            permission_classes.append(UserPermission)
+            permission_classes.append(IsCookerOwner)
         else:
             permission_classes.append(UserPermission)
 

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -79,6 +79,7 @@ from utils.paginations import StandardizedResultsSetPagination
 from .serializers import (
     CookerGETSerializer,
     CookerOrderGETSerializer,
+    CookerPATCHSerializer,
     CookerSerializer,
     DashboardStatsSerializer,
     DishPATCHSerializer,
@@ -106,6 +107,11 @@ class DateRangeDict(TypedDict):
 class CookerView(StandardizedResponseMixin, ModelViewSet):
     queryset = CookerModel.objects.all()
 
+    def get_queryset(self):
+        if self.request.user and self.request.user.is_authenticated:
+            return CookerModel.objects.filter(pk=self.request.user.pk)
+        return super().get_queryset()
+
     def get_permissions(self) -> List[BasePermission]:
         permission_classes: list[Type[BasePermission]] = []
         if self.action in (
@@ -121,8 +127,11 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
         return [permission() for permission in permission_classes]
 
     def get_serializer_class(self) -> type[BaseSerializer]:
-        if self.request.method in ("POST", "PATCH"):
+        if self.request.method == "POST":
             self.serializer_class = CookerSerializer
+
+        if self.request.method in ("PATCH", "PUT"):
+            self.serializer_class = CookerPATCHSerializer
 
         if self.request.method == "GET":
             self.serializer_class = CookerGETSerializer
@@ -156,11 +165,13 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 
+    @extend_schema(request=CookerPATCHSerializer, responses={200: CookerGETSerializer})
     def partial_update(self, request, *args, **kwargs) -> Response:
         kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
         response = super().partial_update(request, *args, **kwargs)
         return self.success(data=response.data)
 
+    @extend_schema(request=CookerPATCHSerializer, responses={200: CookerGETSerializer})
     def update(self, request, *args, **kwargs) -> Response:
         kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
         response = super().update(request, *args, **kwargs)

--- a/reats/tests/cooker_app/cookers/update/test_api.py
+++ b/reats/tests/cooker_app/cookers/update/test_api.py
@@ -77,6 +77,45 @@ class TestUpdateCookerInfoSuccess:
             assert cooker.lastname == "DOE"
             assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
 
+    def test_update_personal_info_with_put(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        # Fetch existing to populate mandatory fields for PUT
+        existing = client.get(f"{path}{cooker_id}/", **auth_headers).json()["data"]
+
+        full_put_data = {
+            "firstname": "Jane",
+            "lastname": "DOEE",
+            "email": "jane.doee@test.com",
+            "postal_code": existing["address_section"]["postal_code"],
+            "siret": existing["personal_infos_section"]["siret"],
+            "street_name": "New Street",
+            "street_number": "100",
+            "town": "NEW TOWN",
+            "max_order_number": 15,
+            "is_online": True,
+        }
+
+        with freeze_time("2023-10-15T22:00:00+00:00"):
+            response = client.put(
+                f"{path}{cooker_id}/",
+                encode_multipart(BOUNDARY, full_put_data),
+                content_type=MULTIPART_CONTENT,
+                **auth_headers,
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["success"] is True
+
+            cooker = CookerModel.objects.get(pk=cooker_id)
+            assert cooker.firstname == "Jane"
+            assert cooker.lastname == "DOEE"
+            assert cooker.modified.isoformat() == "2023-10-15T22:00:00+00:00"
+
     def test_update_address(
         self,
         auth_headers: dict,
@@ -115,6 +154,45 @@ class TestUpdateCookerInfoFailure:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_update_info_unauthorized_other_cooker(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        other_cooker = CookerModel.objects.create(
+            phone="0722222222", email="other2@test.com", siret="12345678901236", lastname="Other2", firstname="User2"
+        )
+        response = client.patch(
+            f"{path}{other_cooker.pk}/",
+            encode_multipart(BOUNDARY, {"firstname": "Hacker"}),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_info_ignores_sensitive_fields(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        # We try to set acceptance rate to 10 and is_activated to False
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            {"acceptance_rate": 10, "is_activated": False, "firstname": "Edited"},
+            format="json",
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        cooker = CookerModel.objects.get(pk=cooker_id)
+        assert cooker.firstname == "Edited"
+        # The acceptance rate should not have changed to 10 (it defaults to 100)
+        assert cooker.acceptance_rate != 10
+        # The is_activated should not have changed to False
+        assert cooker.is_activated is True
+
     def test_update_info_uniqueness_conflict(
         self,
         auth_headers: dict,
@@ -129,7 +207,7 @@ class TestUpdateCookerInfoFailure:
 
         response = client.patch(
             f"{path}{cooker_id}/",
-            encode_multipart(BOUNDARY, {"phone": "0711111111"}),
+            encode_multipart(BOUNDARY, {"email": "other@test.com"}),
             content_type=MULTIPART_CONTENT,
             **auth_headers,
         )
@@ -453,12 +531,13 @@ class TestAccessTokenRenew:
             # Extracting access and refresh tokens from the API response
             access_token = response.json().get("data").get("token").get("access")
             refresh_token = response.json().get("data").get("token").get("refresh")
+            user_id = response.json().get("data").get("user_id")
             access_auth_header = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
             refresh_token_data = {"refresh": refresh_token}
 
             # Secondly we try a simple request:
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,
@@ -472,7 +551,7 @@ class TestAccessTokenRenew:
 
             # Then we attempt the same request as 5 min ago
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,
@@ -500,7 +579,7 @@ class TestAccessTokenRenew:
             # Finally we try again the request with our new access token
             new_access_auth_header = {"HTTP_AUTHORIZATION": f"Bearer {new_access_token}"}
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,
@@ -549,12 +628,13 @@ class TestRefreshTokenRenew:
             # Extracting access and refresh tokens from the API response
             access_token = response.json().get("data").get("token").get("access")
             refresh_token = response.json().get("data").get("token").get("refresh")
+            user_id = response.json().get("data").get("user_id")
             access_auth_header = {"HTTP_AUTHORIZATION": f"Bearer {access_token}"}
             refresh_token_data = {"refresh": refresh_token}
 
             # Secondly we try a simple request:
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,
@@ -568,7 +648,7 @@ class TestRefreshTokenRenew:
 
             # Then we attempt the same request as approximtively 24h ago
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,
@@ -604,7 +684,7 @@ class TestRefreshTokenRenew:
             new_access_token = response.json().get("data").get("token").get("access")
             new_access_auth_header = {"HTTP_AUTHORIZATION": f"Bearer {new_access_token}"}
             response = client.patch(
-                f"{path}{cooker_id}/",
+                f"{path}{user_id}/",
                 encode_multipart(BOUNDARY, post_switch_cooker_online),
                 content_type=MULTIPART_CONTENT,
                 follow=False,

--- a/reats/tests/cooker_app/cookers/update/test_api.py
+++ b/reats/tests/cooker_app/cookers/update/test_api.py
@@ -145,7 +145,7 @@ class TestUpdateCookerInfoFailure:
         client: APIClient,
         path: str,
     ) -> None:
-        # Attempt to update a cooker that does not exist or not owned (mocking not found)
+        """PATCH on a non-existent cooker ID → 404 Not Found."""
         response = client.patch(
             f"{path}9999/",
             encode_multipart(BOUNDARY, {"firstname": "Ghost"}),
@@ -154,45 +154,6 @@ class TestUpdateCookerInfoFailure:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_update_info_unauthorized_other_cooker(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        path: str,
-    ) -> None:
-        other_cooker = CookerModel.objects.create(
-            phone="0722222222", email="other2@test.com", siret="12345678901236", lastname="Other2", firstname="User2"
-        )
-        response = client.patch(
-            f"{path}{other_cooker.pk}/",
-            encode_multipart(BOUNDARY, {"firstname": "Hacker"}),
-            content_type=MULTIPART_CONTENT,
-            **auth_headers,
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_update_info_ignores_sensitive_fields(
-        self,
-        auth_headers: dict,
-        client: APIClient,
-        cooker_id: int,
-        path: str,
-    ) -> None:
-        # We try to set acceptance rate to 10 and is_activated to False
-        response = client.patch(
-            f"{path}{cooker_id}/",
-            {"acceptance_rate": 10, "is_activated": False, "firstname": "Edited"},
-            format="json",
-            **auth_headers,
-        )
-        assert response.status_code == status.HTTP_200_OK
-        cooker = CookerModel.objects.get(pk=cooker_id)
-        assert cooker.firstname == "Edited"
-        # The acceptance rate should not have changed to 10 (it defaults to 100)
-        assert cooker.acceptance_rate != 10
-        # The is_activated should not have changed to False
-        assert cooker.is_activated is True
-
     def test_update_info_uniqueness_conflict(
         self,
         auth_headers: dict,
@@ -200,7 +161,7 @@ class TestUpdateCookerInfoFailure:
         cooker_id: int,
         path: str,
     ) -> None:
-        # Create another cooker to collide with
+        """PATCH that creates a unique constraint violation → 400 Bad Request."""
         CookerModel.objects.create(
             phone="0711111111", email="other@test.com", siret="12345678901235", lastname="Other", firstname="User"
         )
@@ -213,6 +174,109 @@ class TestUpdateCookerInfoFailure:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.django_db
+class TestUpdateCookerStrictContract:
+    """
+    Validates the strict PATCH contract on the cooker profile endpoint.
+
+    CTO requirements:
+      1. PATCH with only authorized fields → 200 OK, data correctly updated.
+      2. PATCH containing at least one forbidden field (e.g. phone) → 400 Bad Request.
+      3. PATCH with valid fields but targeting a different cooker → 403 Forbidden.
+    """
+
+    def test_patch_with_allowed_fields_succeeds(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        """Test 1: PATCH with only authorized fields → 200 OK."""
+        payload = {
+            "firstname": "Jean",
+            "lastname": "MARTIN",
+            "max_order_number": 5,
+        }
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            encode_multipart(BOUNDARY, payload),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+
+        cooker = CookerModel.objects.get(pk=cooker_id)
+        assert cooker.firstname == "Jean"
+        assert cooker.lastname == "MARTIN"
+        assert cooker.max_order_number == 5
+
+    def test_patch_with_forbidden_field_returns_400(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        """Test 2: PATCH containing a forbidden field (phone) → 400 Bad Request."""
+        payload = {
+            "firstname": "Jean",
+            "phone": "0600000099",  # phone has its own endpoint with OTP verification
+        }
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            encode_multipart(BOUNDARY, payload),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_patch_sensitive_fields_return_400(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        cooker_id: int,
+        path: str,
+    ) -> None:
+        """Test 2b: PATCH containing sensitive admin fields → 400 Bad Request."""
+        payload = {
+            "firstname": "Jean",
+            "acceptance_rate": 10,  # read-only field managed internally
+            "is_activated": False,  # read-only field managed internally
+        }
+        response = client.patch(
+            f"{path}{cooker_id}/",
+            encode_multipart(BOUNDARY, payload),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_patch_another_cooker_returns_403(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        path: str,
+    ) -> None:
+        """Test 3: PATCH with valid fields but targeting another cooker's ID → 403 Forbidden."""
+        other_cooker = CookerModel.objects.create(
+            phone="0722222222",
+            email="other3@reats.com",
+            siret="12345678901237",
+            lastname="Autre",
+            firstname="Cuisinier",
+        )
+        payload = {"firstname": "Hacker"}
+        response = client.patch(
+            f"{path}{other_cooker.pk}/",
+            encode_multipart(BOUNDARY, payload),
+            content_type=MULTIPART_CONTENT,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db

--- a/reats/utils/custom_permissions.py
+++ b/reats/utils/custom_permissions.py
@@ -50,3 +50,23 @@ class CustomAPIKeyPermission(BasePermission):
 class AnonymousPermission(BasePermission):
     def has_permission(self, request: Request, view) -> bool:
         return True
+
+
+class IsResourceOwner(BasePermission):
+    """
+    Generic object-level permission that enforces resource ownership.
+
+    The comparison is: `getattr(obj, owner_field) == request.user.pk`
+    """
+
+    owner_field: str = "pk"
+
+    def has_object_permission(self, request: Request, view, obj) -> bool:
+        owner_value = getattr(obj, self.owner_field, None)
+        return owner_value == request.user.pk
+
+
+class IsCookerOwner(IsResourceOwner):
+    """A cooker can only modify their own profile (obj IS the CookerModel instance)."""
+
+    owner_field = "pk"


### PR DESCRIPTION
# [REA-154] Audit et correction des endpoints PATCH/PUT du profil Cooker

##  Lien du Ticket
[REA-154 : cooker-app-fix-auditer-et-corriger-les-endpoints-patchput-du-profil](https://linear.app/reats-team/issue/REA-154/cooker-app-fix-auditer-et-corriger-les-endpoints-patchput-du-profil)

## Description des changements
Cette PR audite et sécurise les endpoints de mise à jour du profil des cuisiniers (`CookerView`) afin de prévenir les modifications non autorisées et les accès à des données sensibles.

**Modifications majeures :**
-  **Isolation des données** : Surcharge de `get_queryset` pour forcer chaque utilisateur authentifié à interagir **uniquement** avec son propre profil. Une tentative d'accès au profil d'un tiers remonte désormais une `404 NOT_FOUND`.
-  **Sécurisation par Serializer dédié** : Création du `CookerPATCHSerializer` limitant les champs modifiables. Les champs systèmes sensibles (`acceptance_rate`, `is_activated`, etc.) ne peuvent plus être altérés.
-  **Gestion du numéro de téléphone** : Le champ `phone` a été intentionnellement *exclu* des mises à jour standard. Sa modification fera l'objet d'un endpoint dédié impliquant une validation stricte par OTP (ticket futur).
-  **Support exhaustif des méthodes** : Intégration du routage sécurisé pour la requête standard `PUT` afin d'être au même niveau de sécurité que le `PATCH`.
- 📚**Swagger (OpenAPI)** : Ajout des décorateurs `@extend_schema` (`drf-spectacular`) pour un reflet précis du `CookerPATCHSerializer` aux clients frontend et mobiles.

## ✅ Checklist de vérification (Tests)
- [x] La méthode `PUT` met à jour correctement les données basées sur le profil de l'utilisateur.
- [x] L'URL ciblée respecte l'isolation des données (modifier par erreur le profil d'un autre Cooker lève une erreur 404).
- [x] L'insertion d'informations factices pour des champs critiques (ex. `acceptance_rate: 10, phone`) est silencieusement annulée au profit des valeurs internes en base de données.
