### PR TITLE
Feat/rea 155 logout blacklist refresh token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 !*-tpl
 *.venv
+*.txt
+*/__pycache__/*
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -33,7 +33,10 @@ from rest_framework_simplejwt.serializers import (
     TokenObtainPairSerializer,
     TokenRefreshSerializer,
 )
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.settings import api_settings
+from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
+from rest_framework_simplejwt.tokens import RefreshToken, Token
+from rest_framework_simplejwt.utils import datetime_from_epoch
 from utils.common import (
     compute_order_items_total_amount,
     format_phone,
@@ -379,7 +382,29 @@ class DrinkPATCHSerializer(DrinkSerializer):
         )
 
 
+class CustomRefreshToken(RefreshToken):
+    @classmethod
+    def for_user(cls, user):
+        token = Token.for_user.__func__(cls, user)
+
+        if "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS:
+            jti = token[api_settings.JTI_CLAIM]
+            exp = token["exp"]
+
+            OutstandingToken.objects.create(
+                user=None,
+                jti=jti,
+                token=str(token),
+                created_at=token.current_time,
+                expires_at=datetime_from_epoch(exp),
+            )
+
+        return token
+
+
 class TokenObtainPairWithoutPasswordSerializer(TokenObtainPairSerializer):
+    token_class = CustomRefreshToken
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["password"].required = False
@@ -430,7 +455,7 @@ class TokenObtainPairWithoutPasswordSerializer(TokenObtainPairSerializer):
         if self.user is None:
             return {"ok": False, "status": status.HTTP_400_BAD_REQUEST}
 
-        refresh = cast(RefreshToken, self.get_token(cast(AbstractBaseUser, self.user)))
+        refresh = cast(CustomRefreshToken, self.get_token(cast(AbstractBaseUser, self.user)))
         data = {}
         data["refresh"] = str(refresh)
         data["access"] = str(refresh.access_token)

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -37,16 +37,20 @@ from drf_spectacular.utils import (
     OpenApiResponse,
     OpenApiTypes,
     extend_schema,
+    inline_serializer,
 )
 from phonenumbers.phonenumberutil import NumberParseException
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin, UpdateModelMixin
 from rest_framework.permissions import BasePermission
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
+from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenViewBase
 from utils.common import (
     activate_user,
@@ -1881,6 +1885,37 @@ class TokenObtainRefreshWithoutPasswordView(StandardizedResponseMixin, TokenView
             raise
 
         return self.success(data=serializer.validated_data, message=SuccessMessageEnum.TOKEN_REFRESHED)
+
+
+class LogoutView(StandardizedResponseMixin, APIView):
+    permission_classes = [UserPermission]
+
+    @extend_schema(
+        request=inline_serializer(name="LogoutRequest", fields={"refresh": serializers.CharField()}),
+        responses={200: OpenApiResponse(description="Successfully logged out.")},
+        tags=["Auth"],
+    )
+    def post(self, request):
+        try:
+            refresh_token = request.data.get("refresh")
+            if not refresh_token:
+                return self.error(
+                    ErrorMessageEnum.INVALID_DATA,
+                    code=ErrorCodeEnum.MISSING_PARAMETERS,
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                )
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+            return self.success(
+                message=SuccessMessageEnum.LOGOUT_SUCCESSFUL,
+                status_code=status.HTTP_200_OK,
+            )
+        except TokenError:
+            return self.error(
+                ErrorMessageEnum.INVALID_DATA,
+                code=ErrorCodeEnum.INVALID_DATA,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class CookerOrderView(

--- a/reats/source/settings.py
+++ b/reats/source/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "django_filters",
     "drf_spectacular",
+    "rest_framework_simplejwt.token_blacklist",
     "customer_app",
     "cooker_app",
     "delivery_app",
@@ -266,6 +267,8 @@ SIMPLE_JWT = {
     "SIGNING_KEY": private_key,
     "VERIFYING_KEY": public_key,
     "TOKEN_OBTAIN_SERIALIZER": "cookers_app.serializers.TokenObtainPairWithoutPasswordSerializer",
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
 }
 
 SERVICE_FEES_RATE = 0.07

--- a/reats/source/urls.py
+++ b/reats/source/urls.py
@@ -95,6 +95,11 @@ urlpatterns = [
         name="token_refresh",
     ),
     path(
+        "api/v1/logout/",
+        cooker_app_views.LogoutView.as_view(),
+        name="logout",
+    ),
+    path(
         "api/v1/stripe/webhook/",
         customer_app_views.StripeWebhookView.as_view({"post": "create"}),
         name="stripe_webhook",

--- a/reats/tests/conftest.py
+++ b/reats/tests/conftest.py
@@ -220,6 +220,8 @@ def simple_jwt_overload(settings, private_key: str, public_key: str) -> None:
         "SIGNING_KEY": private_key,
         "VERIFYING_KEY": public_key,
         "TOKEN_OBTAIN_SERIALIZER": "cookers_app.serializers.TokenObtainPairWithoutPasswordSerializer",
+        "ROTATE_REFRESH_TOKENS": True,
+        "BLACKLIST_AFTER_ROTATION": True,
     }
 
 

--- a/reats/utils/enums.py
+++ b/reats/utils/enums.py
@@ -83,6 +83,7 @@ class SuccessMessageEnum(str, Enum):
     DRINK_DELETED = _("Drink deleted successfully")
     TOKEN_GENERATED = _("Token generated successfully")
     TOKEN_REFRESHED = _("Token refreshed successfully")
+    LOGOUT_SUCCESSFUL = _("Deconnexion reussie")
 
 
 class ErrorCodeEnum(str, Enum):


### PR DESCRIPTION

## feat(auth): support de la blacklist des refresh tokens sans modèle User natif et réparation des tests de rotation
[Tikect](https://linear.app/reats-team/issue/REA-155/cooker-app-feat-implementer-la-deconnexion-logout-and-verifier-le)

Description
Cette Pull Request résout le bug majeur soulevé par la mise sur liste noire des RefreshToken lors de l'authentification et de la déconnexion, ainsi qu'un problème secondaire impactant la vérification de la rotation de ces mêmes tokens dans notre environnement de test.

Contexte et Problème
La bibliothèque rest_framework_simplejwt.token_blacklist impose strictement d'associer un modèle de profil natif Django (User) lors de la création d'un OutstandingToken. Étant donné que le système d'authentification du projet utilise des modèles d'acteurs personnalisés (ex: CookerModel, CustomerModel), la tentative de SimpleJWT d'assigner notre utilisateur personnalisé à la clé étrangère générait une erreur de validation fatale : ValueError: Cannot assign "<CookerModel...>": "OutstandingToken.user" must be a "User" instance.