### PR TITLE
refactor: optimize status filtering logic in CookerOrderView.list and…

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -1288,7 +1288,7 @@ class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet
     @extend_schema(
         summary="Delete a dish",
         description=(
-            "Soft-deletes a dish by setting `is_deleted=True`. " "The dish will no longer appear in list responses."
+            "Soft-deletes a dish by setting `is_deleted=True`. The dish will no longer appear in list responses."
         ),
         responses={200: OpenApiResponse(description="Dish deleted successfully")},
         examples=[
@@ -1821,7 +1821,7 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
     @extend_schema(
         summary="Delete a drink",
         description=(
-            "Soft-deletes a drink by setting `is_deleted=True`. " "The drink will no longer appear in list responses."
+            "Soft-deletes a drink by setting `is_deleted=True`. The drink will no longer appear in list responses."
         ),
         responses={200: OpenApiResponse(description="Drink deleted successfully")},
         examples=[
@@ -1986,18 +1986,19 @@ class CookerOrderView(
 
     def list(self, request, *args, **kwargs) -> Response:
         queryset = self.filter_queryset(self.get_queryset())
-        request_status: Union[str, None] = self.request.query_params.get("status")
+        request_status = self.request.query_params.get("status", OrderStatusEnum.PENDING)
 
-        if request_status is None or request_status not in [
+        valid_statuses = [
             OrderStatusEnum.PENDING,
             OrderStatusEnum.PROCESSING,
             OrderStatusEnum.COMPLETED,
-        ]:
-            if request_status is not None:
+        ]
+
+        if request_status not in valid_statuses:
+            if request_status:
                 logger.error(f"Invalid status {request_status}")
             queryset = queryset.none()
-
-        if request_status is not None:
+        else:
             queryset = queryset.filter(status=request_status).order_by("-modified")
 
         page = self.paginate_queryset(queryset)

--- a/reats/customer_app/management/commands/create_pending_orders.py
+++ b/reats/customer_app/management/commands/create_pending_orders.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         count = options["count"]
         cooker_id = 1  # Change if needed
         customer_id = 1  # Change if needed
-        address_id = 3  # Change if needed
+        address_id = 1  # Change if needed
 
         cooker: CookerModel = CookerModel.objects.get(pk=cooker_id)
         assert cooker.is_activated, "Cooker must be activated."


### PR DESCRIPTION
[Cooker_app] –– Refactor : Optimisation de la logique de filtrage par statut dans CookerOrderView.list
[Tikect-REA-173](https://linear.app/reats-team/issue/REA-173/cooker-app-refactor-optimisation-de-la-logique-de-filtrage-par-statut)

Description:

Dans la méthode list de CookerOrderView, la logique de filtrage des statuts contenait un chemin d'exécution redondant (dead code). Lorsqu'un statut invalide était fourni en paramètre (ex: `?status=invalid`), le code évaluait le queryset à .none(), mais continuait d'exécuter la suite du code en appliquant un` .filter(status=...) `et un .order_by() sur ce queryset déjà vide. Bien que cela ne causait pas de bug fonctionnel en production, J'ai tenu a faire cela.