### PR TITLE
Fix: Double écriture du statut dans CookerOrderView.partial_update()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ pythonpath = ["reats"]
 env = [
     "D:ENV=local",
     "D:DB_HOST=localhost",
-    "D:DB_PORT=8001",
+    "D:DB_PORT=5432",
     "D:POSTGRES_DB=reats_local_db",
-    "D:POSTGRES_USER=dev",
-    "D:POSTGRES_PASSWORD=devpassword",
+    "D:POSTGRES_USER=postgres",
+    "D:POSTGRES_PASSWORD=",
 ]
 
 [tool.ruff]

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -1966,10 +1966,7 @@ class CookerOrderView(
 
         update_cooker_acceptance_rate(instance, new_status)
 
-        serializer = self.get_serializer(instance, data=request.data, partial=True)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
-
+        serializer = CookerOrderGETSerializer(instance)
         return self.success(serializer.data)
 
     def get_serializer_class(self) -> type[BaseSerializer]:

--- a/reats/core_app/models.py
+++ b/reats/core_app/models.py
@@ -17,6 +17,7 @@ from django.db.models import (
     PositiveIntegerField,
     TextField,
 )
+from datetime import datetime, timezone
 from utils.enums import OrderStatusEnum
 from utils.models import ReatsModel
 
@@ -460,7 +461,21 @@ class OrderState:
 
     def transition_to(self, order: OrderModel, new_state):
         if self.can_transition_to(new_state):
-            order.status = order.get_reverse_state_map().get(new_state.__class__.__name__)
+            new_status = order.get_reverse_state_map().get(new_state.__class__.__name__)
+            order.status = new_status
+            
+            now = datetime.now(timezone.utc)
+            if new_status in (OrderStatusEnum.CANCELLED_BY_COOKER, OrderStatusEnum.CANCELLED_BY_CUSTOMER):
+                order.cancelled_date = now
+            elif new_status == OrderStatusEnum.PROCESSING:
+                order.processing_date = now
+            elif new_status == OrderStatusEnum.COMPLETED:
+                order.completed_date = now
+            elif new_status == OrderStatusEnum.IN_DELIVERY:
+                order.delivery_in_progress_date = now
+            elif new_status == OrderStatusEnum.DELIVERED:
+                order.delivered_date = now
+
             order.save()
         else:
             raise ValueError(f"Cannot transition from {self.__class__.__name__} to {new_state.__class__.__name__}")

--- a/reats/core_app/models.py
+++ b/reats/core_app/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from django.contrib.postgres.indexes import GinIndex
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.db.models import (
@@ -17,7 +19,6 @@ from django.db.models import (
     PositiveIntegerField,
     TextField,
 )
-from datetime import datetime, timezone
 from utils.enums import OrderStatusEnum
 from utils.models import ReatsModel
 
@@ -463,7 +464,7 @@ class OrderState:
         if self.can_transition_to(new_state):
             new_status = order.get_reverse_state_map().get(new_state.__class__.__name__)
             order.status = new_status
-            
+
             now = datetime.now(timezone.utc)
             if new_status in (OrderStatusEnum.CANCELLED_BY_COOKER, OrderStatusEnum.CANCELLED_BY_CUSTOMER):
                 order.cancelled_date = now

--- a/reats/core_app/serializers.py
+++ b/reats/core_app/serializers.py
@@ -365,32 +365,6 @@ class OrderPATCHSerializer(ModelSerializer):
         model = OrderModel
         fields = ("status",)
 
-    def update(self, instance: OrderModel, validated_data: dict):
-        status = validated_data["status"]
-        instance.status = status
-
-        if status in (
-            OrderStatusEnum.CANCELLED_BY_COOKER,
-            OrderStatusEnum.CANCELLED_BY_CUSTOMER,
-        ):
-            instance.cancelled_date = datetime.now(timezone.utc)
-
-        if status == OrderStatusEnum.PROCESSING:
-            instance.processing_date = datetime.now(timezone.utc)
-
-        if status == OrderStatusEnum.COMPLETED:
-            instance.completed_date = datetime.now(timezone.utc)
-
-        if status == OrderStatusEnum.IN_DELIVERY:
-            instance.delivery_in_progress_date = datetime.now(timezone.utc)
-
-        if status == OrderStatusEnum.DELIVERED:
-            instance.delivered_date = datetime.now(timezone.utc)
-
-        instance.save()
-
-        return instance
-
 
 class OrderRatingSerializer(ModelSerializer):
     class Meta:

--- a/reats/core_app/serializers.py
+++ b/reats/core_app/serializers.py
@@ -1,10 +1,8 @@
-from datetime import datetime, timezone
 from typing import Any, Union
 
 from rest_framework import serializers
 from rest_framework.serializers import CharField, ModelSerializer
 from utils.common import get_pre_signed_url
-from utils.enums import OrderStatusEnum
 
 from .models import (
     CookerModel,

--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -611,8 +611,6 @@ class OrderView(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
 
-        super().partial_update(request, *args, **kwargs)
-        instance.refresh_from_db()
         serializer = OrderGETSerializer(instance)
 
         return self.success(data=serializer.data, message=SuccessMessageEnum.OPERATION_SUCCESSFUL)

--- a/reats/tests/cooker_app/orders/update/test_api.py
+++ b/reats/tests/cooker_app/orders/update/test_api.py
@@ -392,6 +392,60 @@ def test_update_order_from_pending_to_completed_state(
 
 
 @pytest.mark.django_db
+def test_update_order_with_invalid_transition_returns_400_validation_error(
+    auth_headers: dict,
+    client: APIClient,
+    cookers_order_path: str,
+    customer_order_path: str,
+    post_order_data: dict,
+    mock_googlemaps_distance_matrix: MagicMock,
+    mock_stripe_payment_intent_create: MagicMock,
+) -> None:
+    with freeze_time("2024-05-08T10:16:00+00:00"):
+        # First we create a draft order
+        response = client.post(
+            customer_order_path,
+            encode_multipart(
+                BOUNDARY,
+                post_order_data,
+            ),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        order: OrderModel = OrderModel.objects.latest("pk")
+        assert order.status == OrderStatusEnum.DRAFT.value
+
+    # Manually set the order to PENDING status
+    order.status = OrderStatusEnum.PENDING.value
+    order.save()
+
+    assert order.status == OrderStatusEnum.PENDING.value
+
+    with freeze_time("2024-05-08T10:18:00+00:00"):
+        # Try to transition directly from PENDING to COMPLETED
+        invalid_transition_response = client.patch(
+            f"{cookers_order_path}{order.id}/",
+            encode_multipart(
+                BOUNDARY,
+                {
+                    "status": OrderStatusEnum.COMPLETED.value,
+                },
+            ),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        # Should return 400 Bad Request
+        assert invalid_transition_response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = invalid_transition_response.json()
+        assert "Cannot transition from PendingState to CompletedState" in response_data["error"]["message"]
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "new_status",
     [


### PR DESCRIPTION
 **### Refactor:** 
Centralisation de la State Machine et Optimisation des Commandes

 **### Description**

Cette PR vise à stabiliser le cycle de vie des commandes en résolvant un bug critique de "double-write" . La logique de transition d'état et la gestion des timestamps associés sont aussi  centralisées dans le modèle, garantissant une source de vérité unique et une meilleure intégrité des données.

