### PR TITLE
Fix: Suppression du double-wrapping sur les réponses d'API (PATCH/PUT) (REA-177)

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -178,14 +178,20 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
 
     @extend_schema(request=CookerPATCHSerializer, responses={200: CookerGETSerializer})
     def partial_update(self, request, *args, **kwargs) -> Response:
-        kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
+        kwargs.pop("pk", None)
         response = super().partial_update(request, *args, **kwargs)
+
+        updated_cooker = self.get_object()
+        logger.info(f"[PATCH] Cooker {updated_cooker.pk} updated in memory. Lastname: {updated_cooker.lastname}")
         return self.success(data=response.data)
 
     @extend_schema(request=CookerPATCHSerializer, responses={200: CookerGETSerializer})
     def update(self, request, *args, **kwargs) -> Response:
-        kwargs.pop("pk", None)  # Ensure pk is handled smoothly by parent
+        kwargs.pop("pk", None)
         response = super().update(request, *args, **kwargs)
+
+        updated_cooker = self.get_object()
+        logger.info(f"[PUT] Cooker {updated_cooker.pk} updated in memory. Lastname: {updated_cooker.lastname}")
         return self.success(data=response.data)
 
     @action(detail=True, methods=["patch"], url_path="photo")

--- a/reats/tests/cooker_app/cookers/update/test_api.py
+++ b/reats/tests/cooker_app/cookers/update/test_api.py
@@ -70,6 +70,12 @@ def cooker_response_keys() -> list:
     ]
 
 
+def assert_response_structure(response_body: dict, expected_data: dict, keys: list) -> None:
+    """Extrait un sous-ensemble de clés de la réponse et le compare aux données attendues."""
+    actual_subset = {k: response_body["data"].get(k) for k in keys}
+    assert actual_subset == expected_data
+
+
 @pytest.mark.django_db
 class TestUpdateCookerInfoSuccess:
     def test_update_personal_info(
@@ -94,7 +100,7 @@ class TestUpdateCookerInfoSuccess:
             assert response_body["success"] is True
             assert response_body["message"] == "Operation successful"
 
-            self.assert_response_structure(
+            assert_response_structure(
                 response_body,
                 {
                     "id": cooker_id,
@@ -154,7 +160,7 @@ class TestUpdateCookerInfoSuccess:
             assert response_body["success"] is True
             assert response_body["message"] == "Operation successful"
 
-            self.assert_response_structure(
+            assert_response_structure(
                 response_body,
                 {
                     "id": cooker_id,
@@ -176,11 +182,6 @@ class TestUpdateCookerInfoSuccess:
             # On vérifie uniquement la date de modification en DB car elle n'est pas dans la réponse API
             cooker = CookerModel.objects.get(pk=cooker_id)
             assert cooker.modified.isoformat() == "2023-10-15T22:00:00+00:00"
-
-    def assert_response_structure(self, response_body: dict, expected_data: dict, keys: list) -> None:
-        """Extrait un sous-ensemble de clés de la réponse et le compare aux données attendues."""
-        actual_subset = {k: response_body["data"].get(k) for k in keys}
-        assert actual_subset == expected_data
 
     def test_update_address(
         self,
@@ -259,6 +260,7 @@ class TestUpdateCookerStrictContract:
         client: APIClient,
         cooker_id: int,
         path: str,
+        cooker_response_keys: list,
     ) -> None:
         """Test 1: PATCH with only authorized fields → 200 OK."""
         payload = {
@@ -273,7 +275,27 @@ class TestUpdateCookerStrictContract:
             **auth_headers,
         )
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()["success"] is True
+        response_body = response.json()
+        assert response_body["success"] is True
+
+        assert_response_structure(
+            response_body,
+            {
+                "id": cooker_id,
+                "firstname": "Jean",
+                "lastname": "MARTIN",
+                "email": "test@gmail.com",
+                "postal_code": "91000",
+                "siret": "00000000000001",
+                "street_name": "rue André Lalande",
+                "street_number": "1",
+                "town": "Evry",
+                "address_complement": None,
+                "max_order_number": 5,
+                "is_online": True,
+            },
+            cooker_response_keys,
+        )
 
         cooker = CookerModel.objects.get(pk=cooker_id)
         assert cooker.firstname == "Jean"

--- a/reats/tests/cooker_app/cookers/update/test_api.py
+++ b/reats/tests/cooker_app/cookers/update/test_api.py
@@ -51,6 +51,25 @@ def cooker_id() -> int:
     return 1
 
 
+@pytest.fixture
+def cooker_response_keys() -> list:
+    """Liste des clés essentielles à vérifier dans la réponse du profil Cooker."""
+    return [
+        "id",
+        "firstname",
+        "lastname",
+        "email",
+        "postal_code",
+        "siret",
+        "street_name",
+        "street_number",
+        "town",
+        "address_complement",
+        "max_order_number",
+        "is_online",
+    ]
+
+
 @pytest.mark.django_db
 class TestUpdateCookerInfoSuccess:
     def test_update_personal_info(
@@ -60,6 +79,7 @@ class TestUpdateCookerInfoSuccess:
         cooker_id: int,
         path: str,
         post_personal_information_data_without_photo: dict,
+        cooker_response_keys: list,
     ) -> None:
         with freeze_time("2023-10-14T22:00:00+00:00"):
             response = client.patch(
@@ -70,11 +90,31 @@ class TestUpdateCookerInfoSuccess:
             )
 
             assert response.status_code == status.HTTP_200_OK
-            assert response.json()["success"] is True
+            response_body = response.json()
+            assert response_body["success"] is True
+            assert response_body["message"] == "Operation successful"
 
+            self.assert_response_structure(
+                response_body,
+                {
+                    "id": cooker_id,
+                    "firstname": "John",
+                    "lastname": "DOE",
+                    "email": "test@gmail.com",
+                    "postal_code": "91000",
+                    "siret": "00000000000001",
+                    "street_name": "rue André Lalande",
+                    "street_number": "1",
+                    "town": "Evry",
+                    "address_complement": None,
+                    "max_order_number": 12,
+                    "is_online": True,
+                },
+                cooker_response_keys,
+            )
+
+            # On vérifie uniquement la date de modification en DB car elle n'est pas dans la réponse API
             cooker = CookerModel.objects.get(pk=cooker_id)
-            assert cooker.firstname == "John"
-            assert cooker.lastname == "DOE"
             assert cooker.modified.isoformat() == "2023-10-14T22:00:00+00:00"
 
     def test_update_personal_info_with_put(
@@ -83,6 +123,7 @@ class TestUpdateCookerInfoSuccess:
         client: APIClient,
         cooker_id: int,
         path: str,
+        cooker_response_keys: list,
     ) -> None:
         # Fetch existing to populate mandatory fields for PUT
         existing = client.get(f"{path}{cooker_id}/", **auth_headers).json()["data"]
@@ -109,12 +150,37 @@ class TestUpdateCookerInfoSuccess:
             )
 
             assert response.status_code == status.HTTP_200_OK
-            assert response.json()["success"] is True
+            response_body = response.json()
+            assert response_body["success"] is True
+            assert response_body["message"] == "Operation successful"
 
+            self.assert_response_structure(
+                response_body,
+                {
+                    "id": cooker_id,
+                    "firstname": "Jane",
+                    "lastname": "DOEE",
+                    "email": "jane.doee@test.com",
+                    "postal_code": existing["address_section"]["postal_code"],
+                    "siret": existing["personal_infos_section"]["siret"],
+                    "street_name": "New Street",
+                    "street_number": "100",
+                    "town": "NEW TOWN",
+                    "address_complement": None,
+                    "max_order_number": 15,
+                    "is_online": True,
+                },
+                cooker_response_keys,
+            )
+
+            # On vérifie uniquement la date de modification en DB car elle n'est pas dans la réponse API
             cooker = CookerModel.objects.get(pk=cooker_id)
-            assert cooker.firstname == "Jane"
-            assert cooker.lastname == "DOEE"
             assert cooker.modified.isoformat() == "2023-10-15T22:00:00+00:00"
+
+    def assert_response_structure(self, response_body: dict, expected_data: dict, keys: list) -> None:
+        """Extrait un sous-ensemble de clés de la réponse et le compare aux données attendues."""
+        actual_subset = {k: response_body["data"].get(k) for k in keys}
+        assert actual_subset == expected_data
 
     def test_update_address(
         self,

--- a/reats/utils/custom_api_reponse.py
+++ b/reats/utils/custom_api_reponse.py
@@ -97,6 +97,9 @@ class CustomApiResponse:
         extra_data: dict | None = None,
         headers: dict | None = None,
     ) -> Response:
+        if isinstance(data, dict) and {"success", "data", "message"}.issubset(data.keys()):
+            return Response(data, status=status_code, headers=headers)
+
         payload: dict = {
             "success": True,
             "data": data if data is not None else {},


### PR DESCRIPTION
##  Description
Cette PR corrige un bug critique affectant la structure des réponses renvoyées par les requêtes `PATCH` et `PUT` (notamment sur le profil Cooker). 

Précédemment, la réponse était imbriquée en double (double-wrapped payload) avec la structure suivante :
```json
{
  "success": true,
  "data": {
    "success": true,
    "data": { "id": 4, "firstname": "Joel" },
    "message": "Operation successful"
  },
  "message": "Operation successful"
}
```
Ce format non standard cassait le parsing côté client (mobile/web).

##  Cause
Dans DRF (`UpdateModelMixin`), la méthode `partial_update()` délègue nativement son exécution à `self.update()`. 
Comme nous avions surchargé à la fois `update()` et `partial_update()` dans `CookerView`, l'appel transitait par :
1. `CookerView.update()` -> Qui enveloppait la réponse avec `return self.success(...)` une 1ère fois.
2. Retour vers `CookerView.partial_update()` -> Qui enveloppait à nouveau la réponse avec `return self.success(...)` une 2ème fois.

## Modifications apportées
1. **Sécurisation Globale (Refactoring de `CustomApiResponse.success`) :**
   - Mise à jour de la méthode dans `reats/utils/custom_api_reponse.py` pour détecter automatiquement si les données reçues sont déjà au format de réponse standard (présence des clés `success`, `data`, `message`).
   - Si les données sont déjà formatées, la méthode retourne directement la réponse sans la ré-encapsuler.
   - Utilisation d'une évaluation Pythonic sûre et basée sur le short-circuiting pour éviter les crashs si la variable `data` est nulle : `if isinstance(data, dict) and {"success", "data", "message"}.issubset(data.keys()):`
2. **Nettoyage des vues :**
   - Suppression des "hacks" défensifs manuels (`if isinstance(response.data, dict)...`) ajoutés précédemment dans `update` et `partial_update` de la `CookerView`. La logique de présentation est désormais purement gérée par l'utilitaire de réponse.

## 🔗 Lien vers le ticket Linear
[REA-177](https://linear.app/reats-team/issue/REA-177/fix-suppression-du-double-wrapping-sur-les-reponses-dapi-patchput)
