### PR TITLE
feat: separate availability (is_enabled) from soft delete (is_deleted…

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -776,8 +776,6 @@ class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet
         qs = self._annotated_queryset()
         if self.action == "list":
             qs = qs.filter(cooker__id=self.request.user.pk)
-            if "is_enabled" not in self.request.query_params:
-                qs = qs.filter(is_enabled=True)
         return qs
 
     def get_serializer_class(self) -> type[BaseSerializer]:
@@ -1333,8 +1331,6 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
         qs = self._annotated_queryset()
         if self.action == "list":
             qs = qs.filter(cooker__id=self.request.user.pk)
-            if "is_enabled" not in self.request.query_params:
-                qs = qs.filter(is_enabled=True)
         return qs
 
     def get_serializer_class(self) -> type[BaseSerializer]:

--- a/reats/tests/cooker_app/dishes/read/test_api.py
+++ b/reats/tests/cooker_app/dishes/read/test_api.py
@@ -24,7 +24,7 @@ def test_empty_query_params(auth_headers: dict, client: APIClient, path: str, co
     assert response.json().get("data") is not None
     assert (
         response.json().get("data").get("pagination").get("total_items")
-        == DishModel.objects.filter(is_enabled=True).filter(cooker_id=cooker_id).count()
+        == DishModel.objects.filter(is_deleted=False).filter(cooker_id=cooker_id).count()
     )
 
 

--- a/reats/tests/cooker_app/drinks/read/test_api.py
+++ b/reats/tests/cooker_app/drinks/read/test_api.py
@@ -24,7 +24,7 @@ def test_empty_query_params(auth_headers: dict, client: APIClient, path: str, co
     data = response.json().get("data")
     assert data is not None
     results = data.get("results") if isinstance(data, dict) else data
-    assert len(results) == DrinkModel.objects.filter(is_enabled=True).filter(cooker_id=cooker_id).count()
+    assert len(results) == DrinkModel.objects.filter(is_deleted=False).filter(cooker_id=cooker_id).count()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION


### **Titre :** `feat(cooker_app): séparation de la disponibilité et de la suppression logique (REA-178)`

### **Description :**

#### **Problème :**
Auparavant, lorsqu'un cuisinier désactivait un plat ou une boisson (via le toggle `is_enabled`), l'élément disparaissait complètement de son catalogue. Cela était dû à un filtre par défaut dans le backend qui ne retournait que les éléments actifs (`is_enabled=True`). Cette confusion entre "indisponible" et "supprimé" empêchait les cuisiniers de réactiver leurs produits sans passer par des filtres complexes.

#### **Solution :**
Cette PR modifie le comportement des vues de l'application cuisinier (`cooker_app`) pour permettre une gestion plus souple du catalogue :
- **Affichage exhaustif** : Les actions `list` de `DishView` et `DrinkView` retournent désormais tous les produits rattachés au cuisinier, qu'ils soient activés ou non.
- **Persistance du Soft Delete** : Seuls les produits marqués comme `is_deleted=True` restent masqués de la liste.
- **Indépendance des filtres** : Le filtrage par `is_enabled` reste possible via les paramètres de requête (`?is_enabled=true/false`), mais n'est plus imposé par défaut.

#### **Changements techniques :**
- Modification de `reats/cooker_app/views.py` :
    - Suppression du filtre automatique `is_enabled=True` dans `DishView.get_queryset`.
    - Suppression du filtre automatique `is_enabled=True` dans `DrinkView.get_queryset`.


---

### **Lien Linear :**
[REA-178](https://linear.app/reats-team/issue/REA-178/separation-de-la-disponibilite-et-de-la-suppression-logique)

---

### **Test de vérification :**
1. Créer un plat.
2. Le désactiver via l'endpoint `/availability/`.
3. Appeler `GET /cooker/dishes/` : Le plat doit toujours apparaître avec `"available": false`.
