### PR TITLE
Anonymous phone number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ pythonpath = ["reats"]
 env = [
     "D:ENV=local",
     "D:DB_HOST=localhost",
-    "D:DB_PORT=5432",
+    "D:DB_PORT=8001",
     "D:POSTGRES_DB=reats_local_db",
-    "D:POSTGRES_USER=postgres",
-    "D:POSTGRES_PASSWORD=",
+    "D:POSTGRES_USER=dev",
+    "D:POSTGRES_PASSWORD=devpassword",
 ]
 
 [tool.ruff]

--- a/reats/core_app/management/commands/init_data.py
+++ b/reats/core_app/management/commands/init_data.py
@@ -29,8 +29,17 @@ User = get_user_model()
 class Command(BaseCommand):
     help = "Seed the database with initial data for development (Users, Menu, Orders)"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--phone",
+            type=str,
+            required=True,
+            help="Phone number used to create/retrieve sample customer, cooker, and deliver users.",
+        )
+
     def handle(self, *args, **options):
         self.stdout.write(self.style.SUCCESS("Starting data seeding..."))
+        phone = options["phone"].strip()
 
         # --- 0. Superuser Creation ---
         superuser_email = "admin@reats.com"
@@ -52,7 +61,7 @@ class Command(BaseCommand):
             defaults={
                 "firstname": "John",
                 "lastname": "Doe",
-                "phone": "+33753790506",
+                "phone": phone,
                 "siret": "12345678901234",
                 "postal_code": "75001",
                 "town": "Paris",
@@ -69,7 +78,7 @@ class Command(BaseCommand):
 
         # Customer
         customer, created = CustomerModel.objects.get_or_create(
-            phone="+33753790506",
+            phone=phone,
             defaults={
                 "firstname": "Jane",
                 "lastname": "Smith",
@@ -90,7 +99,7 @@ class Command(BaseCommand):
 
         # Deliver
         deliver, created = DeliverModel.objects.get_or_create(
-            phone="+33753790506",
+            phone=phone,
             defaults={
                 "firstname": "Jack",
                 "lastname": "Fast",

--- a/reats/core_app/tests/test_init_data.py
+++ b/reats/core_app/tests/test_init_data.py
@@ -2,23 +2,29 @@ import pytest
 from core_app.models import CookerModel, CustomerModel, DeliverModel, DishModel, DrinkModel, OrderModel
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 User = get_user_model()
 
 
 @pytest.mark.django_db
-def test_init_data_command():
-    """
-    Test that the init_data command successfully creates users, menu items, and orders.
-    """
+def test_init_data_command_requires_phone_argument():
+    with pytest.raises(CommandError, match="the following arguments are required: --phone"):
+        call_command("init_data")
+
+
+@pytest.mark.django_db
+def test_init_data_command_with_phone_creates_seed_data():
     # Ensure database is clean (pytest-django handles this transactionally, but good to be sure logic works on empty db)
     assert CookerModel.objects.count() == 0
     assert CustomerModel.objects.count() == 0
     assert OrderModel.objects.count() == 0
     assert User.objects.count() == 0
 
-    # Run the command
-    call_command("init_data")
+    phone = "+33600000000"
+
+    # Run the command with required argument
+    call_command("init_data", phone=phone)
 
     # Verify Superuser
     assert User.objects.filter(username="admin@reats.com", is_superuser=True).exists()
@@ -27,11 +33,11 @@ def test_init_data_command():
     assert CookerModel.objects.filter(email="cooker@example.com").exists()
     assert CookerModel.objects.get(email="cooker@example.com").is_activated
 
-    assert CustomerModel.objects.filter(phone="+33753790506").exists()
-    assert CustomerModel.objects.get(phone="+33753790506").is_activated
+    assert CustomerModel.objects.filter(phone=phone).exists()
+    assert CustomerModel.objects.get(phone=phone).is_activated
 
-    assert DeliverModel.objects.filter(phone="+33753790506").exists()
-    deliver = DeliverModel.objects.get(phone="+33753790506")
+    assert DeliverModel.objects.filter(phone=phone).exists()
+    deliver = DeliverModel.objects.get(phone=phone)
     assert deliver.is_activated
     # assert deliver.is_online # Depending on logic, might toggle. init_data sets it to True.
 
@@ -47,8 +53,17 @@ def test_init_data_command():
     statuses = set(OrderModel.objects.values_list("status", flat=True))
     assert len(statuses) > 1, "Should have multiple order statuses generated"
 
+
+@pytest.mark.django_db
+def test_init_data_command_is_idempotent_for_core_seed_entities():
+    phone = "+33600000000"
+
+    call_command("init_data", phone=phone)
     initial_dish_count = DishModel.objects.count()
-    call_command("init_data")
+
+    call_command("init_data", phone=phone)
 
     assert DishModel.objects.count() == initial_dish_count, "Dishes should not be duplicated"
     assert CookerModel.objects.count() == 1, "Cooker should not be duplicated"
+    assert CustomerModel.objects.filter(phone=phone).count() == 1, "Customer should not be duplicated"
+    assert DeliverModel.objects.filter(phone=phone).count() == 1, "Deliver should not be duplicated"


### PR DESCRIPTION
Description

- Ce repo est public donc n'importe qui sur internet peut à minima le lire.
- Suppression d’un numéro de téléphone **réel** codé en dur dans la commande init_data.
- Ajout d’un argument CLI obligatoire --phone pour injecter le numéro au moment de l’exécution.
- Utilisation du numéro fourni pour la création/récupération des données de seed (CookerModel, CustomerModel, DeliverModel).

