### PR TITLE
[REA-200] feat(cooker-app): aligner la structure des items dans le détail de commande

### DIFF
--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -18,11 +18,11 @@ from core_app.models import (
     OrderModel,
 )
 from core_app.serializers import (
+    DishGETSerializer,
     DishNutritionalInfoSerializer,
+    DrinkListSerializer,
     DrinkNutritionalInfoSerializer,
     IngredientDrinkSerializer,
-    OrderDishItemGETSerializer,
-    OrderDrinkItemGETSerializer,
 )
 from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
@@ -578,6 +578,20 @@ class CookerOrderListDrinkSerializer(BaseCookerOrderItemSerializer):
         return f"{obj.drink.capacity}{unit_suffix}"
 
 
+class CookerOrderDetailDishSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        data = DishGETSerializer(instance.dish, context=self.context).data
+        data["quantity"] = instance.dish_quantity
+        return data
+
+
+class CookerOrderDetailDrinkSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        data = DrinkListSerializer(instance.drink, context=self.context).data
+        data["quantity"] = instance.drink_quantity
+        return data
+
+
 class CookerOrderListSerializer(serializers.ModelSerializer):
     customer = CookerOrderCustomerGETSerializer()
     address = CookerAddressSerializer()
@@ -623,8 +637,8 @@ class CookerOrderListSerializer(serializers.ModelSerializer):
 
 class CookerOrderGETSerializer(ModelSerializer):
     address = CookerAddressSerializer()
-    dishes_items = OrderDishItemGETSerializer(many=True)
-    drinks_items = OrderDrinkItemGETSerializer(many=True)
+    dishes_items = CookerOrderDetailDishSerializer(many=True)
+    drinks_items = CookerOrderDetailDrinkSerializer(many=True)
     customer = CookerOrderCustomerGETSerializer()
 
     class Meta:


### PR DESCRIPTION
## Summary

Cetre Pr vise à structurer les données au niveau des commandes

 Problème actuel (detail view) :
```json
"dishes_items": [
  {
    "dish": { "id": 1, "name": "...", "ratings": [], "cooker": {...}, ... },
    "dish_quantity": 2
  },
  {
    "dish": { "id": 2, "name": "...", "ratings": [], "cooker": {...}, ... },
    "dish_quantity": 2
  },
]
```

Structure attendue (alignée avec le listing) :

```json
"dishes_items": [
  {
    "id": 1,
    "name": "...",
    "image": "...",
    "unit_price": 10.0,
    "quantity": 2
  },
{
    "id": 2,
    "name": "...",
    "image": "...",
    "unit_price": 10.0,
    "quantity": 2
  }
]
```

Critères d'acceptation :

* dishes_items et drinks_items dans le détail ont une structure plate identique au listing
* Les tests du endpoint détail sont mis à jour

