### PR TITLE
feat(cooker-app): verify cooker existence before sending OTP and add …

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -324,6 +324,16 @@ class CookerView(StandardizedResponseMixin, ModelViewSet):
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 
+        try:
+            CookerModel.objects.get(phone=e164_phone_format)
+        except CookerModel.DoesNotExist:
+            logger.error(f"Cooker with phone {e164_phone_format} does not exist.")
+            return self.error(
+                message=ErrorMessageEnum.USER_NOT_FOUND,
+                code=ErrorCodeEnum.USER_NOT_FOUND,
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
         send_otp(e164_phone_format)
 
         return self.success(message=SuccessMessageEnum.OTP_SENT_FR)

--- a/reats/tests/cooker_app/cookers/create/test_api.py
+++ b/reats/tests/cooker_app/cookers/create/test_api.py
@@ -418,7 +418,7 @@ class TestCookerAskNewOTP:
         ],
     )
     @pytest.mark.django_db
-    def test_cooker_ask_new_OTP_failed(
+    def test_cooker_ask_new_OTP_failed_with_invalid_phone_number(
         self,
         cooker_api_key_header: dict,
         data: dict,
@@ -434,6 +434,27 @@ class TestCookerAskNewOTP:
             **cooker_api_key_header,
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        send_otp_message_success.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_cooker_ask_new_OTP_failed_cooker_not_found(
+        self,
+        cooker_api_key_header: dict,
+        client: APIClient,
+        otp_path: str,
+        send_otp_message_success: MagicMock,
+    ) -> None:
+        response = client.post(
+            otp_path,
+            encode_multipart(BOUNDARY, {"phone": "0700000001"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **cooker_api_key_header,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json().get("success") is False
+        assert response.json().get("error").get("code") == ErrorCodeEnum.USER_NOT_FOUND
+        assert response.json().get("error").get("message") == ErrorMessageEnum.USER_NOT_FOUND
         send_otp_message_success.assert_not_called()
 
     @pytest.mark.django_db


### PR DESCRIPTION

##  Contexte
- `CookerView.ask_otp` envoyait un SMS OTP sans vérifier si le numéro de téléphone correspondait à un cooker existant
- Ce comportement entraînait des appels SMS inutiles (et donc des coûts) pour des numéros inconnus.
-  Ticket lié : [REA-202](https://linear.app/reats-team/issue/REA-202/fixcooker-app-verify-cooker-existence-in-ask-otp-before-sending-otp)

##  Modifications apportées
- [ ] `cooker_app/views.py` modifié : ajout d'un `CookerModel.objects.get()` dans `ask_otp` — retourne `404 USER_NOT_FOUND` si le cooker n'existe pas, avant tout appel à `send_otp()`
- [ ] `tests/cooker_app/cookers/create/test_api.py` modifié : ajout du cas `test_cooker_ask_new_OTP_failed_cooker_not_found` dans `TestCookerAskNewOTP`
-  Le comportement aligné sur `CustomerView.ask_otp` (ligne 183–208) qui sert de référence

## Tests & Vérification
- [x] Test unitaire ajouté : `TestCookerAskNewOTP::test_cooker_ask_new_OTP_failed_cooker_not_found`

