### PR TITLE
feat(customer-app): add retrieve endpoint for customer order detail (…

### DIFF
--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -31,7 +31,7 @@ from phonenumbers.phonenumberutil import NumberParseException
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.mixins import CreateModelMixin, ListModelMixin, UpdateModelMixin
+from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
@@ -587,6 +587,7 @@ class StarterView(StandardizedResponseMixin, ListModelMixin, GenericViewSet):
 class OrderView(
     StandardizedResponseMixin,
     CreateModelMixin,
+    RetrieveModelMixin,
     ListModelMixin,
     UpdateModelMixin,
     GenericViewSet,
@@ -697,6 +698,25 @@ class OrderView(
             self.serializer_class = OrderPATCHSerializer
 
         return super().get_serializer_class()
+
+    @extend_schema(
+        summary="Get order details",
+        description=(
+            "Returns the full details of a single order belonging to the authenticated customer.\n\n"
+            "Works for orders in any status (active orders as well as history). "
+            "Returns 404 if the order does not exist or belongs to another customer."
+        ),
+        responses={
+            200: OpenApiResponse(response=OrderGETSerializer, description="Order details"),
+            404: OpenApiResponse(description="Order not found"),
+        },
+        tags=["Customer Orders"],
+    )
+    def retrieve(self, request, *args, **kwargs) -> Response:
+        self.queryset = self.queryset.filter(customer__id=request.user.pk)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return self.success(data=serializer.data, message=SuccessMessageEnum.OPERATION_SUCCESSFUL)
 
     def list(self, request, *args, **kwargs) -> Response:
         self.queryset = self.queryset.filter(customer__id=request.user.pk)

--- a/reats/tests/customer_app/orders/read/test_api.py
+++ b/reats/tests/customer_app/orders/read/test_api.py
@@ -446,3 +446,86 @@ def test_orders_list_success(
     diff = DeepDiff(actual_results, expected_data, ignore_order=True)
 
     assert not diff, f"Differences found: {diff}"
+
+
+@pytest.mark.django_db
+def test_retrieve_order_success_for_active_order(
+    auth_headers: dict,
+    client: APIClient,
+    customer_id: int,
+    customer_order_path: str,
+) -> None:
+    order = OrderModel.objects.filter(customer__id=customer_id, status=OrderStatusEnum.PENDING.value).first()
+    assert order is not None, "Aucune commande active trouvée pour ce client dans les fixtures"
+
+    response = client.get(f"{customer_order_path}{order.id}/", follow=False, **auth_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body.get("success") is True
+    assert body.get("message") == SuccessMessageEnum.OPERATION_SUCCESSFUL.value
+
+    data = body.get("data", {})
+    assert data.get("id") == order.id
+    assert data.get("status") == OrderStatusEnum.PENDING.value
+    # Computed fields exposed by OrderGETSerializer
+    assert "sub_total" in data
+    assert "service_fees" in data
+    assert "total_amount" in data
+
+
+@pytest.mark.django_db
+def test_retrieve_order_success_for_history_order(
+    auth_headers: dict,
+    client: APIClient,
+    customer_id: int,
+    customer_order_path: str,
+) -> None:
+    # The endpoint must work for any status, including terminal ones (history).
+    order = OrderModel.objects.filter(customer__id=customer_id, status=OrderStatusEnum.COMPLETED.value).first()
+    assert order is not None, "Aucune commande terminée trouvée pour ce client dans les fixtures"
+
+    response = client.get(f"{customer_order_path}{order.id}/", follow=False, **auth_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json().get("data", {}).get("id") == order.id
+
+
+@pytest.mark.django_db
+def test_retrieve_order_not_found_for_another_customer_order(
+    auth_headers: dict,
+    client: APIClient,
+    customer_id: int,
+    customer_order_path: str,
+) -> None:
+    # An order belonging to ANOTHER customer must not be distinguishable from
+    # a non-existent one: we return 404 to avoid leaking its existence.
+    order = OrderModel.objects.exclude(customer__id=customer_id).first()
+    assert order is not None
+
+    response = client.get(f"{customer_order_path}{order.id}/", follow=False, **auth_headers)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json().get("success") is False
+
+
+@pytest.mark.django_db
+def test_retrieve_order_not_found_for_unknown_order(
+    auth_headers: dict,
+    client: APIClient,
+    customer_order_path: str,
+) -> None:
+    response = client.get(f"{customer_order_path}999999/", follow=False, **auth_headers)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json().get("success") is False
+
+
+@pytest.mark.django_db
+def test_retrieve_order_requires_authentication(
+    client: APIClient,
+    customer_order_path: str,
+) -> None:
+    response = client.get(f"{customer_order_path}1/", follow=False)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Contexte

Le `CookerOrderView` expose déjà `GET /api/v1/cookers-orders/{id}/` (REA-181), mais
le `OrderView` côté client n'avait pas d'équivalent : un client ne pouvait pas
récupérer le détail d'une commande unique. Cet endpoint est nécessaire à l'app mobile
pour l'écran de suivi/détail d'une commande (statut, items, montants), d'autant plus
utile depuis la capture manuelle et les transitions de statut.

Closes REA-217

## Changements

- Ajout de `RetrieveModelMixin` au `OrderView`.
- Nouvelle méthode `retrieve` renvoyant le détail via `OrderGETSerializer`
  (déjà mappé pour les requêtes GET).
- Portée : **toutes** les commandes du client (actives **et** historique),
  quel que soit le statut.
- Documentation OpenAPI (`extend_schema` + tag `Customer Orders`).

## Sécurité

Le queryset est filtré sur `customer__id=request.user.pk` avant `get_object()`.
Une commande qui n'existe pas **ou** qui appartient à un autre client renvoie
un **404 indifférencié** : on ne renvoie volontairement pas de 403, pour ne pas
révéler l'existence d'une commande d'autrui (les `id` étant séquentiels, un 403
permettrait d'énumérer le volume de commandes de la plateforme — information
disclosure / IDOR enumeration, cf. recommandation OWASP).

## Endpoint

`GET /api/v1/customers-orders/{id}/`
