### PR TITLE
fix(orders): release Stripe authorization on pending order cancellation (REA-219)

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -53,6 +53,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenViewBase
 from utils.common import (
     activate_user,
+    cancel_payment_intent,
     capture_payment_intent,
     compute_order_items_total_amount,
     compute_order_total_amount,
@@ -2059,6 +2060,7 @@ class CookerOrderView(
         return self.success(serializer.data)
 
     def _perform_cooker_action(self, instance: OrderModel, new_status: OrderStatusEnum) -> Response:
+        previous_status = instance.status
         if new_status == OrderStatusEnum.CANCELLED:
             instance.cancelled_by = CancelledByEnum.COOKER.value
         try:
@@ -2080,10 +2082,13 @@ class CookerOrderView(
         if new_status == OrderStatusEnum.ACCEPTED:
             capture_payment_intent(instance)
         if new_status == OrderStatusEnum.CANCELLED:
-            amount_to_refund_in_cents = Decimal(
-                str(compute_order_items_total_amount(instance) + instance.delivery_fees)
-            ) * Decimal("100")
-            create_stripe_refund(int(amount_to_refund_in_cents), instance.stripe_payment_intent_id)
+            if previous_status == OrderStatusEnum.PENDING:
+                cancel_payment_intent(instance)
+            else:
+                amount_to_refund_in_cents = Decimal(
+                    str(compute_order_items_total_amount(instance) + instance.delivery_fees)
+                ) * Decimal("100")
+                create_stripe_refund(int(amount_to_refund_in_cents), instance.stripe_payment_intent_id)
         update_cooker_acceptance_rate(instance, new_status)
         return self.success(CookerOrderGETSerializer(instance).data)
 

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -2084,7 +2084,11 @@ class CookerOrderView(
         if new_status == OrderStatusEnum.CANCELLED:
             if previous_status == OrderStatusEnum.PENDING:
                 cancel_payment_intent(instance)
-            else:
+            elif previous_status in (
+                OrderStatusEnum.ACCEPTED,
+                OrderStatusEnum.PREPARING,
+                OrderStatusEnum.READY,
+            ):
                 amount_to_refund_in_cents = Decimal(
                     str(compute_order_items_total_amount(instance) + instance.delivery_fees)
                 ) * Decimal("100")

--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from datetime import datetime, timezone
-from decimal import Decimal
 from typing import Type, Union
 
 from core_app.models import (
@@ -39,10 +38,9 @@ from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from utils.common import (
     activate_user,
-    compute_order_items_total_amount,
+    cancel_payment_intent,
     create_payment_intent,
     create_stripe_customer,
-    create_stripe_refund,
     delete_s3_object,
     delete_stripe_customer,
     format_phone,
@@ -662,10 +660,7 @@ class OrderView(
         if new_status == OrderStatusEnum.CANCELLED:
             instance.cancelled_by = CancelledByEnum.CUSTOMER.value
             if instance.status == OrderStatusEnum.PENDING:
-                amount_to_refund_in_cents = Decimal(
-                    str(compute_order_items_total_amount(instance) + instance.delivery_fees)
-                ) * Decimal("100")
-                create_stripe_refund(int(amount_to_refund_in_cents), instance.stripe_payment_intent_id)
+                cancel_payment_intent(instance)
 
         if new_status:
             try:

--- a/reats/tests/cooker_app/orders/update/test_api.py
+++ b/reats/tests/cooker_app/orders/update/test_api.py
@@ -57,6 +57,7 @@ def test_update_order_from_pending_to_cancelled_by_cooker_status(
     mock_googlemaps_distance_matrix: MagicMock,
     mock_stripe_payment_intent_create: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
 ) -> None:
     with freeze_time("2024-05-08T10:16:00+00:00"):
         response = client.post(
@@ -93,10 +94,8 @@ def test_update_order_from_pending_to_cancelled_by_cooker_status(
         origins=["13 rue des Mazières 91000 Evry"],
         destinations=["1 rue André Lalande 91000 Evry"],
     )
-    mock_stripe_create_refund_success.assert_called_once_with(
-        amount=2319,
-        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-    )
+    mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+    mock_stripe_create_refund_success.assert_not_called()
     mock_stripe_payment_intent_create.assert_called_once_with(
         amount=2459,
         currency="EUR",
@@ -405,6 +404,7 @@ def test_update_cooker_acceptance_rate_on_cancel(
     mock_googlemaps_distance_matrix: MagicMock,
     mock_stripe_payment_intent_create: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
     cooker_id: int,
 ) -> None:
     OrderModel.objects.exclude(status=OrderStatusEnum.COMPLETED.value).delete()
@@ -456,10 +456,8 @@ def test_update_cooker_acceptance_rate_on_cancel(
         capture_method="manual",
         customer="cus_QyZ76Ae0W5KeqP",
     )
-    mock_stripe_create_refund_success.assert_called_once_with(
-        amount=2319,
-        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-    )
+    mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+    mock_stripe_create_refund_success.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/reats/tests/customer_app/orders/update/test_api.py
+++ b/reats/tests/customer_app/orders/update/test_api.py
@@ -58,6 +58,7 @@ def test_switch_order_status_from_draft_to_cancelled_by_customer(
     mock_stripe_payment_intent_create: MagicMock,
     mock_stripe_create_ephemeral_key: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
 ) -> None:
     with freeze_time("2024-05-08T10:16:00+00:00"):
         # First we create a draft order
@@ -103,10 +104,8 @@ def test_switch_order_status_from_draft_to_cancelled_by_customer(
         origins=["13 rue des Mazières 91000 Evry"],
         destinations=["1 rue André Lalande 91000 Evry"],
     )
-    mock_stripe_create_refund_success.assert_called_once_with(
-        amount=2319,
-        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-    )
+    mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+    mock_stripe_create_refund_success.assert_not_called()
     mock_stripe_payment_intent_create.assert_called_once_with(
         amount=2459,
         currency="EUR",
@@ -130,6 +129,7 @@ def test_switch_order_status_from_draft_to_cancelled_by_cooker(
     mock_stripe_payment_intent_create: MagicMock,
     mock_stripe_create_ephemeral_key: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
 ) -> None:
     with freeze_time("2024-05-08T10:16:00+00:00"):
         # First we create a draft order
@@ -174,10 +174,8 @@ def test_switch_order_status_from_draft_to_cancelled_by_cooker(
         origins=["13 rue des Mazières 91000 Evry"],
         destinations=["1 rue André Lalande 91000 Evry"],
     )
-    mock_stripe_create_refund_success.assert_called_once_with(
-        amount=2319,
-        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-    )
+    mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+    mock_stripe_create_refund_success.assert_not_called()
     mock_stripe_payment_intent_create.assert_called_once_with(
         amount=2459,
         currency="EUR",
@@ -766,6 +764,7 @@ def test_switch_order_status_from_cancelled_by_customer_to_non_allowed_status(
     mock_stripe_payment_intent_create: MagicMock,
     mock_stripe_create_ephemeral_key: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
 ) -> None:
     with freeze_time("2024-05-08T10:16:00+00:00"):
         # Create a draft order
@@ -832,10 +831,8 @@ def test_switch_order_status_from_cancelled_by_customer_to_non_allowed_status(
                 origins=["13 rue des Mazières 91000 Evry"],
                 destinations=["1 rue André Lalande 91000 Evry"],
             )
-    mock_stripe_create_refund_success.assert_called_once_with(
-        amount=2319,
-        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-    )
+    mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+    mock_stripe_create_refund_success.assert_not_called()
     mock_stripe_payment_intent_create.assert_called_once_with(
         amount=2459,
         currency="EUR",
@@ -1476,6 +1473,7 @@ def test_cancel_order_when_initiated_by_customer_and_order_is_still_pending(
     mock_stripe_create_ephemeral_key: MagicMock,
     mock_stripe_webhook_construct_event_success: MagicMock,
     mock_stripe_create_refund_success: MagicMock,
+    mock_stripe_payment_intent_cancel: MagicMock,
 ):
     with freeze_time("2024-11-10T08:16:00+00:00"):
         response = client.post(
@@ -1539,10 +1537,8 @@ def test_cancel_order_when_initiated_by_customer_and_order_is_still_pending(
             stripe_version="2024-06-20",
         )
         mock_stripe_webhook_construct_event_success.assert_called_once()
-        mock_stripe_create_refund_success.assert_called_once_with(
-            amount=2319,
-            payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
-        )
+        mock_stripe_payment_intent_cancel.assert_called_once_with("pi_3Q6VU7EEYeaFww1W0xCZEUxw")
+        mock_stripe_create_refund_success.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## REA-219

https://linear.app/reats-team/issue/REA-219/fixorders-liberer-lautorisation-stripe-sur-annulation-pending-au-lieu

### Contexte
Depuis le passage en capture manuelle (REA-214), une commande `PENDING` n'est qu'autorisée, jamais capturée. Or sur annulation d'une commande PENDING, le code appelait `create_stripe_refund` → **échec Stripe** (rien à rembourser). Concernait les deux côtés :
- Client : `customer_app/views.py`
- Cuisinier : `cooker_app/views.py`

### Changements
- **Client** : annulation d'une commande PENDING → `cancel_payment_intent` (libération de l'autorisation, aucun débit). Imports devenus inutilisés retirés.
- **Cuisinier** : capture de `previous_status` avant la transition ; PENDING → `cancel_payment_intent`, ACCEPTED+ → refund (comportement conservé).

### Critères d'acceptation
- [x] Annulation client d'une commande PENDING → `stripe.PaymentIntent.cancel` appelé, pas de refund
- [x] Annulation cooker d'une commande PENDING → idem
- [x] Annulation depuis ACCEPTED+ → refund conservé
- [x] Tests couvrant les deux chemins