### PR TITLE
test(cooker-app): couvrir l'annulation depuis preparing/ready et corriger la doc de cancel (REA-220)

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -2147,8 +2147,11 @@ class CookerOrderView(
     @extend_schema(
         summary="Cancel an order",
         description=(
-            "Transitions the order to `cancelled` from `pending`, `accepted`, or `preparing`.\n\n"
-            "Triggers a Stripe refund and sets `cancelled_by` to `cooker`."
+            "Transitions the order to `cancelled` from `pending`, `accepted`, `preparing`, or `ready`, "
+            "and sets `cancelled_by` to `cooker`.\n\n"
+            "Stripe handling depends on the previous status: a `pending` order is only authorized, so its "
+            "authorization is released; an order cancelled from `accepted`, `preparing`, or `ready` was "
+            "already captured, so it is refunded."
         ),
         request=None,
         responses={

--- a/reats/tests/cooker_app/orders/update/test_api.py
+++ b/reats/tests/cooker_app/orders/update/test_api.py
@@ -7,7 +7,7 @@ from core_app.models import AddressModel, CookerModel, CustomerModel, OrderModel
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APIClient
-from utils.enums import OrderStatusEnum
+from utils.enums import CancelledByEnum, OrderStatusEnum
 
 # Add this line to ignore E501 errors
 # flake8: noqa: E501
@@ -176,6 +176,112 @@ def test_update_order_from_processing_to_cancelled_by_cooker_status(
         automatic_payment_methods={"enabled": True},
         capture_method="manual",
         customer="cus_QyZ76Ae0W5KeqP",
+    )
+
+
+@pytest.mark.django_db
+def test_update_order_from_preparing_to_cancelled_by_cooker_status(
+    auth_headers: dict,
+    client: APIClient,
+    cookers_order_path: str,
+    customer_order_path: str,
+    post_order_data: dict,
+    mock_googlemaps_distance_matrix: MagicMock,
+    mock_stripe_payment_intent_create: MagicMock,
+    mock_stripe_create_refund_success: MagicMock,
+) -> None:
+    with freeze_time("2024-05-08T10:16:00+00:00"):
+        response = client.post(
+            customer_order_path,
+            post_order_data,
+            format="json",
+            follow=False,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        order: OrderModel = OrderModel.objects.latest("pk")
+        assert order.status == OrderStatusEnum.DRAFT.value
+
+    order.status = OrderStatusEnum.PENDING.value
+    order.save()
+
+    with freeze_time("2024-05-08T10:18:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/accept/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    with freeze_time("2024-05-08T10:19:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/start-preparation/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    order.refresh_from_db()
+    assert order.status == OrderStatusEnum.PREPARING.value
+
+    with freeze_time("2024-05-08T10:25:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/cancel/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    order.refresh_from_db()
+    assert order.status == OrderStatusEnum.CANCELLED.value
+    assert order.cancelled_by == CancelledByEnum.COOKER.value
+    mock_stripe_create_refund_success.assert_called_once_with(
+        amount=2319,
+        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
+    )
+
+
+@pytest.mark.django_db
+def test_update_order_from_ready_to_cancelled_by_cooker_status(
+    auth_headers: dict,
+    client: APIClient,
+    cookers_order_path: str,
+    customer_order_path: str,
+    post_order_data: dict,
+    mock_googlemaps_distance_matrix: MagicMock,
+    mock_stripe_payment_intent_create: MagicMock,
+    mock_stripe_create_refund_success: MagicMock,
+) -> None:
+    with freeze_time("2024-05-08T10:16:00+00:00"):
+        response = client.post(
+            customer_order_path,
+            post_order_data,
+            format="json",
+            follow=False,
+            **auth_headers,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        order: OrderModel = OrderModel.objects.latest("pk")
+        assert order.status == OrderStatusEnum.DRAFT.value
+
+    order.status = OrderStatusEnum.PENDING.value
+    order.save()
+
+    with freeze_time("2024-05-08T10:18:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/accept/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    with freeze_time("2024-05-08T10:19:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/start-preparation/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    with freeze_time("2024-05-08T10:30:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/mark-ready/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    order.refresh_from_db()
+    assert order.status == OrderStatusEnum.READY.value
+
+    with freeze_time("2024-05-08T10:35:00+00:00"):
+        response = client.post(f"{cookers_order_path}{order.id}/cancel/", follow=False, **auth_headers)
+        assert response.status_code == status.HTTP_200_OK
+
+    order.refresh_from_db()
+    assert order.status == OrderStatusEnum.CANCELLED.value
+    assert order.cancelled_by == CancelledByEnum.COOKER.value
+    mock_stripe_create_refund_success.assert_called_once_with(
+        amount=2319,
+        payment_intent="pi_3Q6VU7EEYeaFww1W0xCZEUxw",
     )
 
 


### PR DESCRIPTION
## REA-220

https://linear.app/reats-team/issue/REA-220/testcooker-app-couvrir-lannulation-depuis-preparingready-et-corriger

### Contexte
Suite à REA-219, l'action `cancel` côté cuisinier libère l'autorisation Stripe quand la commande est `pending` et rembourse depuis `accepted`/`preparing`/`ready`. Mais :
- La doc OpenAPI de `cancel` indiquait encore « Triggers a Stripe refund » (faux pour `pending`) et oubliait l'état `ready`.
- Les tests ne couvraient l'annulation cuisinier que depuis `pending` et `accepted`.

### Changements
- **Doc** : `@extend_schema` de `cancel` mis à jour — ajout de l'état `ready` et distinction libération d'autorisation (`pending`) vs remboursement (`accepted`/`preparing`/`ready`).
- **Tests** : ajout de `test_update_order_from_preparing_to_cancelled_by_cooker_status` et `test_update_order_from_ready_to_cancelled_by_cooker_status`, vérifiant le remboursement Stripe.

### Critères d'acceptation
- [x] Doc de `cancel` corrigée (deux comportements + état `ready`)
- [x] Test annulation depuis `preparing` → remboursement déclenché
- [x] Test annulation depuis `ready` → remboursement déclenché

### Note
Le test existant `test_update_order_from_processing_to_cancelled_by_cooker_status` teste en réalité l'état `accepted` (malgré son nom). Laissé tel quel — renommage hors scope.