### PR TITLE
feat(cooker-app): exposer is_scheduled et scheduled_delivery_date dans la liste des commandes (REA-222)

### DIFF
--- a/reats/cooker_app/serializers.py
+++ b/reats/cooker_app/serializers.py
@@ -608,6 +608,8 @@ class CookerOrderListSerializer(serializers.ModelSerializer):
             "id",
             "status",
             "created",
+            "is_scheduled",
+            "scheduled_delivery_date",
             "customer",
             "address",
             "dishes_items",

--- a/reats/tests/cooker_app/orders/read/test_api.py
+++ b/reats/tests/cooker_app/orders/read/test_api.py
@@ -24,6 +24,8 @@ def cooker_id() -> int:
                         "id": 9,
                         "status": "pending",
                         "created": "2024-12-11T20:53:05.718117Z",
+                        "is_scheduled": False,
+                        "scheduled_delivery_date": "2024-12-17T16:30:00Z",
                         "customer": {
                             "id": 1,
                             "lastname": "TEN",
@@ -42,6 +44,8 @@ def cooker_id() -> int:
                         "id": 10,
                         "status": "pending",
                         "created": "2024-12-11T20:53:05.718117Z",
+                        "is_scheduled": False,
+                        "scheduled_delivery_date": "2024-12-17T16:30:00Z",
                         "customer": {
                             "id": 1,
                             "lastname": "TEN",
@@ -73,6 +77,8 @@ def cooker_id() -> int:
                         "id": 13,
                         "status": "accepted",
                         "created": "2024-12-11T20:53:05.718117Z",
+                        "is_scheduled": False,
+                        "scheduled_delivery_date": "2024-12-17T16:30:00Z",
                         "customer": {
                             "id": 1,
                             "lastname": "TEN",


### PR DESCRIPTION
## REA-222

https://linear.app/reats-team/issue/REA-222/featcooker-app-exposer-is-scheduled-et-scheduled-delivery-date-dans-la

Le  mobile a besoin de distinguer les commandes anticipées et de les trier par date de livraison, mais la liste des commandes ne renvoyait ni `is_scheduled` ni `scheduled_delivery_date`. Ces deux champs existent pourtant déjà sur le modèle et sont exposés côté client — il manquait juste de les ajouter au serializer de liste cuisinier.

Ce que ça change :

- `GET /api/v1/cookers-orders/` renvoie maintenant `is_scheduled` et `scheduled_delivery_date` pour chaque commande
