### PR TITLE
fix(orders): figer le contenu d'une commande une fois passée (REA-223)

### DIFF
--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -756,6 +756,30 @@ class IngredientsEndpointMixin:
         return self.success(data=response_data)  # type: ignore
 
 
+# Statuses of orders whose amounts are already fixed: while such an order
+# references an item, the item's price cannot change.
+ONGOING_ORDER_STATUSES = [
+    OrderStatusEnum.PENDING,
+    OrderStatusEnum.ACCEPTED,
+    OrderStatusEnum.PREPARING,
+    OrderStatusEnum.READY,
+    OrderStatusEnum.DELIVERING,
+]
+
+
+def _price_change_forbidden(instance, data, item_model, **item_filter) -> bool:
+    """The submitted price differs from the current one while ongoing orders reference the item."""
+    price = data.get("price")
+    if price is None:
+        return False
+    try:
+        if float(price) == float(instance.price):
+            return False
+    except (TypeError, ValueError):
+        pass  # Invalid price: let the guard block it rather than change anything.
+    return item_model.objects.filter(order__status__in=ONGOING_ORDER_STATUSES, **item_filter).exists()
+
+
 class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet):
     """
     Dish management for the authenticated restaurant (cooker).
@@ -987,6 +1011,14 @@ class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+
+        if _price_change_forbidden(instance, request.data, OrderDishItemModel, dish=instance):
+            return self.error(
+                message="The price cannot be changed while ongoing orders reference this dish",
+                code=ErrorCodeEnum.VALIDATION_ERROR,
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
@@ -1505,6 +1537,16 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+
+        # The price cannot change while ongoing orders reference this drink:
+        # the amounts of those orders were computed with the current price.
+        if _price_change_forbidden(instance, request.data, OrderDrinkItemModel, drink=instance):
+            return self.error(
+                message="The price cannot be changed while ongoing orders reference this drink",
+                code=ErrorCodeEnum.VALIDATION_ERROR,
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)

--- a/reats/cooker_app/views.py
+++ b/reats/cooker_app/views.py
@@ -767,17 +767,17 @@ ONGOING_ORDER_STATUSES = [
 ]
 
 
-def _price_change_forbidden(instance, data, item_model, **item_filter) -> bool:
+def _is_changing_item_price_allowed(instance, data, item_model, **item_filter) -> bool:
     """The submitted price differs from the current one while ongoing orders reference the item."""
     price = data.get("price")
     if price is None:
-        return False
+        return True
     try:
         if float(price) == float(instance.price):
-            return False
+            return True
     except (TypeError, ValueError):
         pass  # Invalid price: let the guard block it rather than change anything.
-    return item_model.objects.filter(order__status__in=ONGOING_ORDER_STATUSES, **item_filter).exists()
+    return not item_model.objects.filter(order__status__in=ONGOING_ORDER_STATUSES, **item_filter).exists()
 
 
 class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet):
@@ -1012,7 +1012,7 @@ class DishView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSet
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
 
-        if _price_change_forbidden(instance, request.data, OrderDishItemModel, dish=instance):
+        if not _is_changing_item_price_allowed(instance, request.data, OrderDishItemModel, dish=instance):
             return self.error(
                 message="The price cannot be changed while ongoing orders reference this dish",
                 code=ErrorCodeEnum.VALIDATION_ERROR,
@@ -1540,7 +1540,7 @@ class DrinkView(StandardizedResponseMixin, IngredientsEndpointMixin, ModelViewSe
 
         # The price cannot change while ongoing orders reference this drink:
         # the amounts of those orders were computed with the current price.
-        if _price_change_forbidden(instance, request.data, OrderDrinkItemModel, drink=instance):
+        if not _is_changing_item_price_allowed(instance, request.data, OrderDrinkItemModel, drink=instance):
             return self.error(
                 message="The price cannot be changed while ongoing orders reference this drink",
                 code=ErrorCodeEnum.VALIDATION_ERROR,

--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -644,6 +644,14 @@ class OrderView(
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance: OrderModel = self.get_object()
+
+        if instance.status != OrderStatusEnum.DRAFT:
+            return self.error(
+                message="An order can no longer be modified once it has been placed",
+                code=ErrorCodeEnum.VALIDATION_ERROR,
+                status_code=status.HTTP_409_CONFLICT,
+            )
+
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)

--- a/reats/tests/cooker_app/dishes/update/test_api.py
+++ b/reats/tests/cooker_app/dishes/update/test_api.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from core_app.models import DishModel, DishNutritionalInfo
+from core_app.models import DishModel, DishNutritionalInfo, OrderDishItemModel
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from freezegun import freeze_time
@@ -258,3 +258,75 @@ class TestUpdateDishNutritionalInfoSuccess:
         dish_nutritional_info = DishNutritionalInfo.objects.get(dish=dish)
         for key, value in patch_nutritional_info.items():
             assert getattr(dish_nutritional_info, key) == value
+
+
+@pytest.mark.django_db
+class TestUpdateDishPriceWithOngoingOrderFailure:
+    """The price of a dish referenced by an ongoing order is frozen."""
+
+    @pytest.fixture
+    def ongoing_order_item(self, dish_id: int) -> OrderDishItemModel:
+        # Order 9 belongs to cooker 1 and is pending.
+        return OrderDishItemModel.objects.create(order_id=9, dish_id=dish_id, dish_quantity=1)
+
+    def test_response(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        dish_id: int,
+        ongoing_order_item: OrderDishItemModel,
+        path: str,
+    ) -> None:
+        original_price = DishModel.objects.get(pk=dish_id).price
+
+        response = client.patch(
+            f"{path}{dish_id}/",
+            encode_multipart(BOUNDARY, {"price": "20"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+        assert DishModel.objects.get(pk=dish_id).price == original_price
+
+    def test_other_fields_remain_editable(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        dish_id: int,
+        ongoing_order_item: OrderDishItemModel,
+        path: str,
+    ) -> None:
+        response = client.patch(
+            f"{path}{dish_id}/",
+            encode_multipart(BOUNDARY, {"description": "Still editable"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert DishModel.objects.get(pk=dish_id).description == "Still editable"
+
+    def test_unchanged_price_is_allowed(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        dish_id: int,
+        ongoing_order_item: OrderDishItemModel,
+        path: str,
+    ) -> None:
+        original_price = DishModel.objects.get(pk=dish_id).price
+
+        response = client.patch(
+            f"{path}{dish_id}/",
+            encode_multipart(BOUNDARY, {"price": str(original_price), "description": "New text"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert DishModel.objects.get(pk=dish_id).description == "New text"

--- a/reats/tests/cooker_app/dishes/update/test_api.py
+++ b/reats/tests/cooker_app/dishes/update/test_api.py
@@ -2,12 +2,13 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from core_app.models import DishModel, DishNutritionalInfo, OrderDishItemModel
+from core_app.models import DishModel, DishNutritionalInfo, OrderDishItemModel, OrderModel
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APIClient
+from utils.enums import OrderStatusEnum
 
 
 @pytest.fixture
@@ -266,7 +267,9 @@ class TestUpdateDishPriceWithOngoingOrderFailure:
 
     @pytest.fixture
     def ongoing_order_item(self, dish_id: int) -> OrderDishItemModel:
-        # Order 9 belongs to cooker 1 and is pending.
+        order = OrderModel.objects.get(pk=9)
+        assert int(order.cooker.id) == 1
+        assert order.status == OrderStatusEnum.PENDING
         return OrderDishItemModel.objects.create(order_id=9, dish_id=dish_id, dish_quantity=1)
 
     def test_response(
@@ -298,17 +301,35 @@ class TestUpdateDishPriceWithOngoingOrderFailure:
         dish_id: int,
         ongoing_order_item: OrderDishItemModel,
         path: str,
+        post_data_without_photo: dict,
     ) -> None:
+        patch_data = {
+            "category": "dessert",
+            "description": "New description",
+            "name": "New name",
+            "cost": "10",
+            "preparation_time": 15,
+            "max_concurrent_orders": 5,
+            "is_enabled": False,
+        }
+
         response = client.patch(
             f"{path}{dish_id}/",
-            encode_multipart(BOUNDARY, {"description": "Still editable"}),
+            encode_multipart(BOUNDARY, patch_data),
             content_type=MULTIPART_CONTENT,
             follow=False,
             **auth_headers,
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert DishModel.objects.get(pk=dish_id).description == "Still editable"
+        dish_object = DishModel.objects.get(pk=dish_id)
+        assert dish_object.category == patch_data["category"]
+        assert dish_object.description == patch_data["description"]
+        assert dish_object.name == patch_data["name"]
+        assert dish_object.cost == 10.0
+        assert dish_object.preparation_time == 15
+        assert dish_object.max_concurrent_orders == 5
+        assert dish_object.is_enabled is False
 
     def test_unchanged_price_is_allowed(
         self,

--- a/reats/tests/cooker_app/drinks/update/test_api.py
+++ b/reats/tests/cooker_app/drinks/update/test_api.py
@@ -27,7 +27,7 @@ def post_data_without_photo(ingredients: list[dict]) -> dict:
         "country": "Togo",
         "description": "New description",
         "name": "New name",
-        "price": "3",
+        "price": "5",
         "cooker": 1,
         "capacity": "10",
         "ingredients": json.dumps(ingredients),
@@ -61,7 +61,7 @@ class TestUpdateDrinkWithoutPhotoSuccess:
             assert drink_object.country == "Togo"
             assert drink_object.description == "New description"
             assert drink_object.name == "New name"
-            assert drink_object.price == 3.0
+            assert drink_object.price == 5.0
             assert drink_object.is_enabled is True
             assert drink_object.images.filter(is_primary=True).first().key == "cookers/1/drinks/gingembre.jpg"  # type: ignore
             assert drink_object.modified.isoformat() == "2023-10-14T22:00:00+00:00"
@@ -84,7 +84,7 @@ def post_data_with_photo(image: InMemoryUploadedFile) -> dict:
         "country": "Togo",
         "description": "New description",
         "name": "New name",
-        "price": "3",
+        "price": "5",
         "cooker": 1,
         "capacity": "10",
         "photos": image,
@@ -120,7 +120,7 @@ class TestUpdateDrinkWithPhotoSuccess:
             assert drink_object.country == "Togo"
             assert drink_object.description == "New description"
             assert drink_object.name == "New name"
-            assert drink_object.price == 3.0
+            assert drink_object.price == 5.0
             assert drink_object.is_enabled is True
             assert drink_object.images.filter(is_primary=True).first().key == "cookers/1/drinks/test.jpg"  # type: ignore
             assert drink_object.modified.isoformat() == "2023-10-14T22:00:00+00:00"
@@ -205,3 +205,54 @@ class TestUpdateDrinkToEnableState:
 
             assert drink_object.is_enabled is True
             assert drink_object.modified.isoformat() == "2023-10-21T22:00:00+00:00"
+
+
+@pytest.mark.django_db
+class TestUpdateDrinkPriceWithOngoingOrderFailure:
+    """Drink 2 is referenced by the pending order 1: its price is frozen."""
+
+    def test_response(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        drink_id: int,
+        path: str,
+    ) -> None:
+        response = client.patch(
+            f"{path}{drink_id}/",
+            encode_multipart(BOUNDARY, {"price": "6"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+        assert DrinkModel.objects.get(pk=drink_id).price == 5.0
+
+
+@pytest.mark.django_db
+class TestUpdateDrinkPriceWithoutOngoingOrderSuccess:
+    """Drink 1 is not referenced by any ongoing order: its price can change."""
+
+    @pytest.fixture
+    def drink_id(self) -> int:
+        return 1
+
+    def test_response(
+        self,
+        auth_headers: dict,
+        client: APIClient,
+        drink_id: int,
+        path: str,
+    ) -> None:
+        response = client.patch(
+            f"{path}{drink_id}/",
+            encode_multipart(BOUNDARY, {"price": "6"}),
+            content_type=MULTIPART_CONTENT,
+            follow=False,
+            **auth_headers,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert DrinkModel.objects.get(pk=drink_id).price == 6.0

--- a/reats/tests/customer_app/orders/update/test_api.py
+++ b/reats/tests/customer_app/orders/update/test_api.py
@@ -2032,3 +2032,32 @@ def test_update_order_but_unexpected_exception_raises_on_customer_app(
         mock_stripe_webhook_construct_event_failed.assert_not_called()
         mock_stripe_payment_intent_update.assert_not_called()
         mock_transition_to.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_update_order_fails_once_order_has_been_placed(
+    auth_headers: dict,
+    client: APIClient,
+    customer_order_path: str,
+    post_order_data: dict,
+) -> None:
+    # Order 9 belongs to customer 1 and is pending: its content is frozen.
+    order_id = 9
+    order: OrderModel = OrderModel.objects.get(pk=order_id)
+    assert order.status == OrderStatusEnum.PENDING.value
+
+    response = client.put(
+        f"{customer_order_path}{order_id}/",
+        post_order_data,
+        format="json",
+        follow=False,
+        **auth_headers,
+    )
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    order.refresh_from_db()
+    assert order.status == OrderStatusEnum.PENDING.value
+    assert not OrderDishItemModel.objects.filter(order=order).exists()
+    assert not OrderDrinkItemModel.objects.filter(order=order).exists()


### PR DESCRIPTION
## Contexte

Les montants d'une commande pouvaient dériver si son contenu était modifié après paiement. Plutôt qu'un snapshot de prix par ligne (approche abandonnée, trop lourde), on applique une règle simple : **une commande passée ne se modifie plus**.

## Changements

- `PUT /customers-orders/{id}/` refusé en **409** dès que la commande n'est plus en `draft` — le contenu et les montants sont figés au paiement
- Le client peut toujours **annuler** via PATCH (flux d'annulation/remboursement inchangé)


