### PR TITLE
feat(customer): discovery aléatoire + endpoint menu cuisinier (REA-224)

### DIFF
--- a/docs/CUSTOMER_ONBOARDING_API.md
+++ b/docs/CUSTOMER_ONBOARDING_API.md
@@ -1,4 +1,4 @@
-# API Customer — Documentation Onboarding (Authentification)
+# API Customer — Documentation complète
 
 **Base URL :** `/api/v1/`  
 **Version :** v1
@@ -482,6 +482,93 @@ DELETE /api/v1/customers/{id}/
   "data": {}
 }
 ```
+
+---
+
+## Discovery & Commande
+
+> Auth : `Authorization: Bearer <access_token>`
+
+### 12. Discovery — Liste des plats
+
+```
+GET /api/v1/customers-dishes/
+```
+
+**Auth :** Bearer JWT
+
+**Query params :**
+
+| Paramètre | Type | Obligatoire | Description |
+|---|---|---|---|
+| `search_address_id` | integer | ✅ | ID de l'adresse de livraison du client |
+| `delivery_mode` | string | Non | `now` ou `scheduled` |
+| `category` | string | Non | Filtre par catégorie |
+| `country` | string | Non | Filtre par pays d'origine |
+| `search_radius` | integer | Non | Rayon en km (défaut : 10) |
+| `sort` | string | Non | `new` ou `famous` |
+
+**Comportement :** Retourne les plats des cuisiniers en ligne dans la zone géographique du client, triés aléatoirement. Si aucun cuisinier trouvé dans la zone, retourne une liste vide.
+
+**Response `200` :**
+
+```json
+{
+  "success": true,
+  "message": "Operation successful",
+  "data": [
+    {
+      "id": 5,
+      "name": "Poulet braisé",
+      "price": 3500,
+      "category": "dish",
+      "country": "Cameroun",
+      "is_enabled": true,
+      "cooker": { "id": 1, "firstname": "Marie" }
+    }
+  ]
+}
+```
+
+---
+
+### 13. Menu du cuisinier (EDB)
+
+```
+GET /api/v1/customers-cookers/{cooker_id}/menu/
+```
+
+**Auth :** Bearer JWT
+
+**Quand l'appeler :** immédiatement après que le client a sélectionné un plat. Permet de savoir quelles étapes upsell afficher dans le tunnel de commande.
+
+**Règle d'affichage :** si une liste est vide, ne pas afficher l'étape correspondante. Entre 0 et 3 étapes supplémentaires selon ce que le cuisinier propose.
+
+**Response `200` :**
+
+```json
+{
+  "success": true,
+  "message": "Operation successful",
+  "data": {
+    "extras": [
+      { "id": 10, "name": "Salade de feuilles", "price": 1500, "category": "starter" }
+    ],
+    "desserts": [
+      { "id": 11, "name": "Beignets", "price": 500, "category": "dessert" }
+    ],
+    "drinks": [
+      { "id": 12, "name": "Bissap", "price": 500 }
+    ]
+  }
+}
+```
+
+**Erreurs :**
+
+| HTTP | `error.code` | Cause |
+|---|---|---|
+| `404` | `NOT_FOUND` | Cuisinier introuvable |
 
 ---
 

--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -583,6 +583,62 @@ class StarterView(StandardizedResponseMixin, ListModelMixin, GenericViewSet):
         return self.success(response.data)
 
 
+class CookerMenuView(StandardizedResponseMixin, RetrieveModelMixin, GenericViewSet):
+    permission_classes = [UserPermission]
+
+    @extend_schema(
+        summary="Get cooker full menu (extras, desserts, drinks)",
+        description=(
+            "Returns all enabled extras, desserts and drinks for a given cooker.\n\n"
+            "Call this endpoint immediately after the customer selects a dish. "
+            "Use the response to determine which upsell steps to show: "
+            "only present a category step if its list is non-empty. "
+            "Between 0 and 3 additional steps depending on what the cooker offers. "
+            "No pagination — item count per category is always small."
+        ),
+        responses={
+            200: OpenApiResponse(
+                description="Cooker menu",
+                examples=[
+                    OpenApiExample(
+                        "Cooker with all categories",
+                        value={
+                            "extras": [{"id": 1, "name": "Salade de feuilles", "price": 1500}],
+                            "desserts": [{"id": 2, "name": "Beignets", "price": 500}],
+                            "drinks": [{"id": 3, "name": "Bissap", "price": 500}],
+                        },
+                    ),
+                    OpenApiExample(
+                        "Cooker with drinks only",
+                        value={"extras": [], "desserts": [], "drinks": [{"id": 3, "name": "Bissap", "price": 500}]},
+                    ),
+                ],
+            ),
+            404: OpenApiResponse(description="Cooker not found"),
+        },
+        tags=["Customer Discovery"],
+    )
+    def retrieve(self, request, pk=None) -> Response:
+        if not CookerModel.objects.filter(pk=pk).exists():
+            return self.error(
+                message="Cooker not found",
+                code=ErrorCodeEnum.NOT_FOUND,
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        extras = DishModel.objects.filter(cooker__id=pk, category="starter", is_enabled=True, is_deleted=False)
+        desserts = DishModel.objects.filter(cooker__id=pk, category="dessert", is_enabled=True, is_deleted=False)
+        drinks = DrinkModel.objects.filter(cooker__id=pk, is_enabled=True, is_deleted=False)
+
+        return self.success(
+            {
+                "extras": DishCustomerSerializer(extras, many=True, context={"request": request}).data,
+                "desserts": DishCustomerSerializer(desserts, many=True, context={"request": request}).data,
+                "drinks": DrinkCustomerSerializer(drinks, many=True, context={"request": request}).data,
+            }
+        )
+
+
 class OrderView(
     StandardizedResponseMixin,
     CreateModelMixin,

--- a/reats/customer_app/views.py
+++ b/reats/customer_app/views.py
@@ -491,8 +491,7 @@ class DishView(StandardizedResponseMixin, ListModelMixin, GenericViewSet):
             self.queryset = DishModel.objects.none()
         else:
             if request_sort is None:
-                # Default sort: by acceptance_rate; search_rank ordering is handled by DishFilter
-                self.queryset = self.queryset.order_by("-cooker__acceptance_rate")
+                self.queryset = self.queryset.order_by("?")
 
         response = super().list(request, *args, **kwargs)
         return self.success(response.data)

--- a/reats/source/urls.py
+++ b/reats/source/urls.py
@@ -34,6 +34,7 @@ router.register(r"customers-dishes-countries", customer_app_views.DishCountriesV
 router.register(r"customers-drinks", customer_app_views.DrinkView)
 router.register(r"customers-desserts", customer_app_views.DessertView)
 router.register(r"customers-starters", customer_app_views.StarterView)
+router.register(r"customers-cookers", customer_app_views.CookerMenuView, basename="customers-cookers")
 router.register(
     r"customers-addresses",
     customer_app_views.AddressView,


### PR DESCRIPTION
## Ce que fait cette PR

- Tri aléatoire des plats dans le feed discovery (au lieu d'un tri fixe par `acceptance_rate` — pas assez de données pour un classement significatif pour l'instant)
- Nouvel endpoint `GET /api/v1/customers-cookers/{cooker_id}/menu/` qui retourne en une seule requête les extras, desserts et boissons d'un cuisinier
- Mise à jour de la doc `CUSTOMER_ONBOARDING_API.md` avec le flow discovery complet

## Pourquoi

Le feed discovery affichait toujours les mêmes cuisiniers en tête. Le random assure une rotation équitable tant qu'on n'a pas assez de données pour calibrer un vrai classement.

L'endpoint menu est appelé par le mobile immédiatement après qu'un client sélectionne un plat. Il permet de savoir quelles étapes upsell afficher (extras → desserts → boissons). Si une catégorie est vide, l'étape est sautée — entre 0 et 3 étapes supplémentaires selon ce que le cuisinier propose.

## Tests Manuel effectués.

- [ ] `GET /api/v1/customers-dishes/?search_address_id=X` retourne des plats dans un ordre différent à chaque appel
- [ ] `GET /api/v1/customers-cookers/1/menu/` retourne extras, desserts et boissons du cuisinier id=1
- [ ] `GET /api/v1/customers-cookers/5/menu/` retourne trois listes vides (cuisinier sans EDB)
- [ ] `GET /api/v1/customers-cookers/999/menu/` retourne 404